### PR TITLE
Add gpt-5-codex coverage in docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/ben-vargas/ai-sdk-provider-codex-cli/issues)
 [![Latest Release](https://img.shields.io/github/v/release/ben-vargas/ai-sdk-provider-codex-cli?display_name=tag)](https://github.com/ben-vargas/ai-sdk-provider-codex-cli/releases/latest)
 
-A community provider for Vercel AI SDK v5 that uses OpenAI’s Codex CLI (non‑interactive `codex exec`) to talk to GPT‑5 class models with your ChatGPT Plus/Pro subscription. The provider spawns the Codex CLI process, parses its JSONL output, and adapts it to the AI SDK LanguageModelV2 interface.
+A community provider for Vercel AI SDK v5 that uses OpenAI’s Codex CLI (non‑interactive `codex exec`) to talk to GPT‑5 class models (`gpt-5` and the Codex-specific `gpt-5-codex` slug) with your ChatGPT Plus/Pro subscription. The provider spawns the Codex CLI process, parses its JSONL output, and adapts it to the AI SDK LanguageModelV2 interface.
 
 - Works with `generateText`, `streamText`, and `generateObject` (JSON schemas via prompt engineering)
 - Uses ChatGPT OAuth from `codex login` (tokens in `~/.codex/auth.json`) or `OPENAI_API_KEY`
@@ -39,7 +39,7 @@ Text generation
 import { generateText } from 'ai';
 import { codexCli } from 'ai-sdk-provider-codex-cli';
 
-const model = codexCli('gpt-5', {
+const model = codexCli('gpt-5-codex', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',
@@ -59,8 +59,10 @@ Streaming
 import { streamText } from 'ai';
 import { codexCli } from 'ai-sdk-provider-codex-cli';
 
+// The provider works with both `gpt-5` and `gpt-5-codex`; use the latter for
+// the Codex CLI specific slug.
 const { textStream } = await streamText({
-  model: codexCli('gpt-5', { allowNpx: true, skipGitRepoCheck: true }),
+  model: codexCli('gpt-5-codex', { allowNpx: true, skipGitRepoCheck: true }),
   prompt: 'Write two short lines of encouragement.',
 });
 for await (const chunk of textStream) process.stdout.write(chunk);
@@ -75,7 +77,7 @@ import { codexCli } from 'ai-sdk-provider-codex-cli';
 
 const schema = z.object({ name: z.string(), age: z.number().int() });
 const { object } = await generateObject({
-  model: codexCli('gpt-5', { allowNpx: true, skipGitRepoCheck: true }),
+  model: codexCli('gpt-5-codex', { allowNpx: true, skipGitRepoCheck: true }),
   schema,
   prompt: 'Generate a small user profile.',
 });

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,10 +27,20 @@ node examples/<file>.mjs
   - Demonstrates: `generateText`, provider wiring, safe defaults.
   - Value: Quick sanity check to confirm your environment is correct.
 
+- **basic-usage-gpt-5-codex.mjs:** Minimal generation with the new `gpt-5-codex` slug
+  - Purpose: Confirm the provider works unchanged with the Codex-specific GPT-5 model ID.
+  - Demonstrates: Same call path as above, but with the new slug so you can sanity check quickly.
+  - Value: Handy regression test when Codex CLI ships new model identifiers.
+
 - **streaming.mjs:** Stream responses
   - Purpose: Show the AI SDK streaming API shape.
   - Demonstrates: Reading `textStream` and rendering as chunks.
   - Value: Build responsive UIs. Note: Codex CLI JSON mode suppresses deltas, so you’ll typically receive a final chunk rather than many small ones; the pattern remains the same.
+
+- **streaming-gpt-5-codex.mjs:** Streaming with the `gpt-5-codex` slug
+  - Purpose: Validate stream handling with the Codex-specific model identifier.
+  - Demonstrates: Same stream plumbing while calling the new slug.
+  - Value: Confidence that streaming stays compatible across Codex model updates.
 
 - **conversation-history.mjs:** Maintain context
   - Purpose: Keep multi-turn state using a message array.
@@ -41,6 +51,11 @@ node examples/<file>.mjs
   - Purpose: Use system prompts to steer tone or format.
   - Demonstrates: `system` role to enforce concise or structured replies.
   - Value: Consistency across outputs without repeating instructions.
+
+- **system-messages-gpt-5-codex.mjs:** System prompts with `gpt-5-codex`
+  - Purpose: Mirror the system prompt example against the new slug to ensure compatibility.
+  - Demonstrates: That the conversation mapper/system validation still behaves the same.
+  - Value: Fast compatibility regression check for future Codex CLI updates.
 
 - **custom-config.mjs:** Configure runtime
   - Purpose: Customize CWD and autonomy/sandbox policies per run.
@@ -82,6 +97,11 @@ The provider uses prompt engineering to enforce JSON-only responses, then extrac
   - Purpose: Start with simple, typed objects.
   - Demonstrates: Zod primitives, arrays, and optional fields.
   - Value: Cleanly typed responses for standard data collection.
+
+- **generate-object-basic-gpt-5-codex.mjs:** Fundamentals with `gpt-5-codex`
+  - Purpose: Exercise JSON object generation against the Codex slug.
+  - Demonstrates: Same Zod-driven prompts, proving compatibility with new identifiers.
+  - Value: Quick regression path when Codex CLI ships new GPT-5 model slugs.
 
 - **generate-object-nested.mjs:** Real-world hierarchies
   - Purpose: Work with nested objects and arrays of objects.

--- a/examples/basic-usage-gpt-5-codex.mjs
+++ b/examples/basic-usage-gpt-5-codex.mjs
@@ -1,0 +1,17 @@
+import { generateText } from 'ai';
+import { codexCli } from '../dist/index.js';
+
+const model = codexCli('gpt-5-codex', {
+  allowNpx: true,
+  skipGitRepoCheck: true,
+  approvalMode: 'on-failure',
+  sandboxMode: 'workspace-write',
+  color: 'never',
+});
+
+const { text } = await generateText({
+  model,
+  prompt: 'Reply with a single word: hello.',
+});
+
+console.log('Result:', text);

--- a/examples/generate-object-basic-gpt-5-codex.mjs
+++ b/examples/generate-object-basic-gpt-5-codex.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+/**
+ * Basic Object Generation Examples (Codex CLI)
+ *
+ * Demonstrates fundamental object generation with JSON schema using
+ * the Codex CLI provider. Uses prompt engineering to enforce JSON-only output.
+ */
+
+import { generateObject } from 'ai';
+import { codexCli } from '../dist/index.js';
+import { z } from 'zod';
+
+console.log('🎯 Codex CLI - Basic Object Generation\n');
+
+const model = codexCli('gpt-5-codex', {
+  allowNpx: true,
+  skipGitRepoCheck: true,
+  approvalMode: 'on-failure',
+  sandboxMode: 'workspace-write',
+  color: 'never',
+});
+
+// Example 1: Simple object with primitives
+async function example1_simpleObject() {
+  console.log('1️⃣  Simple Object with Primitives\n');
+
+  const { object } = await generateObject({
+    model,
+    schema: z.object({
+      name: z.string().describe('Full name of the person'),
+      age: z.number().describe('Age in years'),
+      email: z.string().email().describe('Valid email address'),
+      isActive: z.boolean().describe('Whether the account is active'),
+    }),
+    prompt:
+      'Generate a JSON object with a person profile for Alex Smith (age ~30) with a realistic email.',
+  });
+
+  console.log(JSON.stringify(object, null, 2));
+  console.log();
+}
+
+// Example 2: Arrays
+async function example2_arrays() {
+  console.log('2️⃣  Object with Arrays\n');
+
+  const { object } = await generateObject({
+    model,
+    schema: z.object({
+      projectName: z.string(),
+      languages: z.array(z.string()),
+      contributors: z.array(z.string()),
+      stars: z.number(),
+      topics: z.array(z.string()),
+    }),
+    prompt: 'Generate data for an open-source TypeScript web framework project.',
+  });
+
+  console.log(JSON.stringify(object, null, 2));
+  console.log();
+}
+
+// Example 3: Optional fields and basic constraints
+async function example3_optionalFields() {
+  console.log('3️⃣  Optional Fields & Constraints\n');
+
+  const { object } = await generateObject({
+    model,
+    schema: z.object({
+      title: z.string().describe('Book title'),
+      author: z.string().describe('Author name'),
+      isbn: z.string().describe('ISBN-13'),
+      publishedYear: z.number().int().describe('Year of publication'),
+      rating: z.number().min(0).max(5).optional().describe('Average rating 0-5'),
+      awards: z.array(z.string()).optional().describe('Awards if any'),
+    }),
+    prompt: 'Generate metadata for a science fiction novel (not a real title).',
+  });
+
+  console.log(JSON.stringify(object, null, 2));
+  console.log();
+}
+
+await example1_simpleObject();
+await example2_arrays();
+await example3_optionalFields();
+
+console.log('✅ Done');

--- a/examples/streaming-gpt-5-codex.mjs
+++ b/examples/streaming-gpt-5-codex.mjs
@@ -1,0 +1,20 @@
+import { streamText } from 'ai';
+import { codexCli } from '../dist/index.js';
+
+const model = codexCli('gpt-5-codex', {
+  allowNpx: true,
+  skipGitRepoCheck: true,
+  approvalMode: 'on-failure',
+  sandboxMode: 'workspace-write',
+  color: 'never',
+});
+
+const { textStream } = await streamText({
+  model,
+  prompt: 'Write a 1,000 word essay on the history of the internet.',
+});
+
+for await (const chunk of textStream) {
+  process.stdout.write(chunk);
+}
+process.stdout.write('\n');

--- a/examples/system-messages-gpt-5-codex.mjs
+++ b/examples/system-messages-gpt-5-codex.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { generateText } from 'ai';
+import { codexCli } from '../dist/index.js';
+
+const model = codexCli('gpt-5-codex', {
+  allowNpx: true,
+  skipGitRepoCheck: true,
+  approvalMode: 'on-failure',
+  sandboxMode: 'workspace-write',
+  color: 'never',
+});
+
+const messages = [
+  { role: 'system', content: 'You are a terse assistant. Always reply in exactly 3 words.' },
+  { role: 'user', content: 'Describe TypeScript in a nutshell.' },
+];
+
+const { text } = await generateText({ model, messages });
+console.log('System-influenced reply:', text);


### PR DESCRIPTION
## Summary
- highlight the gpt-5-codex slug in the README quick start snippets and intro
- add codex-slug variants of key examples (basic usage, system messages, streaming, object generation)
- document the new scripts in examples/README for easy regression checks

## Testing
- node examples/basic-usage-gpt-5-codex.mjs
- node examples/system-messages-gpt-5-codex.mjs
- node examples/streaming-gpt-5-codex.mjs
- node examples/generate-object-basic-gpt-5-codex.mjs
