### PR TITLE
feat: Add gpt-5.1-codex-max and xhigh reasoning effort support (v0.5.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/ben-vargas/ai-sdk-provider-codex-cli/issues)
 [![Latest Release](https://img.shields.io/github/v/release/ben-vargas/ai-sdk-provider-codex-cli?display_name=tag)](https://github.com/ben-vargas/ai-sdk-provider-codex-cli/releases/latest)
 
-A community provider for Vercel AI SDK v5 that uses OpenAI’s Codex CLI (non‑interactive `codex exec`) to talk to GPT‑5.1 class models (`gpt-5.1`, the Codex-specific `gpt-5.1-codex`, and the lightweight `gpt-5.1-codex-mini` slugs) with your ChatGPT Plus/Pro subscription. The provider spawns the Codex CLI process, parses its JSONL output, and adapts it to the AI SDK LanguageModelV2 interface. Legacy GPT-5 / GPT-5-codex slugs remain compatible for existing workflows.
+A community provider for Vercel AI SDK v5 that uses OpenAI’s Codex CLI (non‑interactive `codex exec`) to talk to GPT‑5.1 class models (`gpt-5.1`, the Codex-specific `gpt-5.1-codex`, the flagship `gpt-5.1-codex-max`, and the lightweight `gpt-5.1-codex-mini` slugs) with your ChatGPT Plus/Pro subscription. The provider spawns the Codex CLI process, parses its JSONL output, and adapts it to the AI SDK LanguageModelV2 interface. Legacy GPT-5 / GPT-5-codex slugs remain compatible for existing workflows.
 
 - Works with `generateText`, `streamText`, and `generateObject` (native JSON Schema support via `--output-schema`)
 - Uses ChatGPT OAuth from `codex login` (tokens in `~/.codex/auth.json`) or `OPENAI_API_KEY`
@@ -28,7 +28,7 @@ npm i -g @openai/codex
 codex login   # or set OPENAI_API_KEY
 ```
 
-> **⚠️ Version Requirement**: Requires Codex CLI **>= 0.42.0** for `--experimental-json` and `--output-schema` support. **>= 0.44.0 recommended** for full usage tracking and tool streaming support. Check your version with `codex --version` and upgrade if needed:
+> **⚠️ Version Requirement**: Requires Codex CLI **>= 0.42.0** for `--experimental-json` and `--output-schema` support. **>= 0.60.0 recommended** for `gpt-5.1-codex-max` and `xhigh` reasoning effort. If you supply your own Codex CLI (global install or custom `codexPath`/`allowNpx`), check it with `codex --version` and upgrade if needed. The optional dependency `@openai/codex` in this package pulls a compatible version automatically.
 >
 > ```bash
 > npm i -g @openai/codex@latest
@@ -248,7 +248,7 @@ const model = codexCli('gpt-5.1-codex', {
   skipGitRepoCheck: true,
 
   // Reasoning & verbosity
-  reasoningEffort: 'medium', // minimal | low | medium | high
+  reasoningEffort: 'medium', // minimal | low | medium | high | xhigh (xhigh only on gpt-5.1-codex-max)
   reasoningSummary: 'auto', // auto | detailed (Note: 'concise' and 'none' are rejected by API)
   reasoningSummaryFormat: 'none', // none | experimental
   modelVerbosity: 'high', // low | medium | high

--- a/docs/ai-sdk-v5/configuration.md
+++ b/docs/ai-sdk-v5/configuration.md
@@ -22,8 +22,8 @@ This provider wraps the `codex exec` CLI in non‑interactive mode and maps sett
 
 ### Reasoning & Verbosity
 
-- **`reasoningEffort`** ('minimal' | 'low' | 'medium' | 'high'): Controls reasoning depth for reasoning-capable models (o3, o4-mini, the GPT-5.1 family, and legacy GPT-5). Higher effort produces more thorough reasoning at the cost of latency. Maps to `-c model_reasoning_effort=<value>`.
-  - Per the Codex CLI model preset definitions (`codex-rs/common/src/model_presets.rs`), `gpt-5.1` and `gpt-5.1-codex` expose `low`, `medium`, and `high`, while `gpt-5.1-codex-mini` only surfaces `medium` and `high`.
+- **`reasoningEffort`** ('minimal' | 'low' | 'medium' | 'high' | 'xhigh'): Controls reasoning depth for reasoning-capable models (o3, o4-mini, the GPT-5.1 family, and legacy GPT-5). Higher effort produces more thorough reasoning at the cost of latency. Maps to `-c model_reasoning_effort=<value>`.
+  - Per the Codex CLI model preset definitions (`codex-rs/common/src/model_presets.rs`), `gpt-5.1` and `gpt-5.1-codex` expose `low`, `medium`, and `high`; `gpt-5.1-codex-max` adds `xhigh`; and `gpt-5.1-codex-mini` only surfaces `medium` and `high`.
   - The older `gpt-5` slug still exposed `minimal`, but the GPT-5.1 family does not; passing `minimal` to a GPT-5.1 slug is rejected server-side.
 - **`reasoningSummary`** ('auto' | 'detailed'): Controls reasoning summary detail level. **Note:** Despite API error messages claiming 'concise' and 'none' are valid, they are rejected with 400 errors. Only 'auto' and 'detailed' work. Maps to `-c model_reasoning_summary=<value>`.
 - **`reasoningSummaryFormat`** ('none' | 'experimental'): Controls reasoning summary format (experimental). Maps to `-c model_reasoning_summary_format=<value>`.

--- a/examples/generate-object-advanced.mjs
+++ b/examples/generate-object-advanced.mjs
@@ -13,12 +13,15 @@ import { z } from 'zod';
 
 console.log('🚀 Codex CLI - Advanced Object Generation\n');
 
-const model = codexCli('gpt-5.1', {
+// Use the Codex flagship model to exercise extra-high reasoning effort.
+// Requires codex-cli >= 0.60 for gpt-5.1-codex-max + xhigh.
+const model = codexCli('gpt-5.1-codex-max', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',
   sandboxMode: 'workspace-write',
   color: 'never',
+  reasoningEffort: 'xhigh', // gpt-5.1-codex-max only; deeper reasoning for structured outputs
 });
 
 // Example 1: Product comparison with scoring and rationale

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-codex-cli",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
@@ -30,7 +30,7 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@openai/codex": "^0.44.0"
+        "@openai/codex": "^0.60.1"
       },
       "peerDependencies": {
         "zod": "^3.0.0 || ^4.0.0"
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.44.0.tgz",
-      "integrity": "sha512-5QNxwcuNn1aZMIzBs9E//vVLLRTZ8jkJRZas2XJgYdBNiSSlGzIuOfPBPXPNiQ2hRPKVqI4/APWIck4jxhw2KA==",
+      "version": "0.60.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.60.1.tgz",
+      "integrity": "sha512-qKLPldoUdBviRBltPxYYqbpOmTpFcIgy3Hbehrcda7kMY7OcdruU3HaTfERXwOXXOl853v8s8hBBpOALLqUCgQ==",
       "license": "Apache-2.0",
       "optional": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "AI SDK v5 provider for OpenAI Codex CLI with native JSON Schema support",
   "keywords": [
     "ai-sdk",
@@ -11,6 +11,7 @@
     "gpt-5",
     "gpt-5.1",
     "gpt-5.1-codex",
+    "gpt-5.1-codex-max",
     "provider"
   ],
   "homepage": "https://github.com/ben-vargas/ai-sdk-provider-codex-cli",
@@ -63,7 +64,7 @@
     "jsonc-parser": "^3.3.1"
   },
   "optionalDependencies": {
-    "@openai/codex": "^0.44.0"
+    "@openai/codex": "^0.60.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -25,4 +25,10 @@ describe('validateSettings', () => {
     expect(res.valid).toBe(false);
     expect(res.errors.some((e) => /reasoningSummary/i.test(e))).toBe(true);
   });
+
+  it('accepts xhigh reasoningEffort for max models', () => {
+    const res = validateSettings({ reasoningEffort: 'xhigh' });
+    expect(res.valid).toBe(true);
+    expect(res.errors).toHaveLength(0);
+  });
 });

--- a/src/codex-cli-language-model.ts
+++ b/src/codex-cli-language-model.ts
@@ -62,7 +62,7 @@ interface ActiveToolItem {
 
 const codexCliProviderOptionsSchema: z.ZodType<CodexCliProviderOptions> = z
   .object({
-    reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
+    reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
     reasoningSummary: z.enum(['auto', 'detailed']).optional(),
     reasoningSummaryFormat: z.enum(['none', 'experimental']).optional(),
     textVerbosity: z.enum(['low', 'medium', 'high']).optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export type ApprovalMode = 'untrusted' | 'on-failure' | 'on-request' | 'never';
 
 export type SandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
 
-export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high';
+export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 /**
  * Reasoning summary detail level.
  * Note: The API error messages claim 'concise' and 'none' are valid, but they are
@@ -99,9 +99,9 @@ export interface CodexCliSettings {
    * Controls reasoning effort for reasoning-capable models (o3, o4-mini, the GPT-5.1 family,
    * and legacy GPT-5 slugs). Higher effort produces more thorough reasoning at the cost of latency.
    *
-   * Codex CLI model presets currently expose `low`/`medium`/`high` for `gpt-5.1` and `gpt-5.1-codex`,
-   * while `gpt-5.1-codex-mini` only offers `medium`/`high`. The legacy `gpt-5` slug still allowed
-   * `minimal`, but GPT-5.1 rejects it.
+   * Codex CLI model presets currently expose `low`/`medium`/`high` for `gpt-5.1` and `gpt-5.1-codex`.
+   * `gpt-5.1-codex-max` additionally supports `xhigh`. `gpt-5.1-codex-mini` only offers `medium`/`high`.
+   * The legacy `gpt-5` slug still allowed `minimal`, but GPT-5.1 rejects it.
    *
    * Maps to: `-c model_reasoning_effort=<value>`
    * @see https://platform.openai.com/docs/guides/reasoning

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -32,7 +32,7 @@ const settingsSchema = z
     logger: z.union([z.literal(false), loggerFunctionSchema]).optional(),
 
     // NEW: Reasoning & Verbosity
-    reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
+    reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
     // Note: API rejects 'concise' and 'none' despite error messages claiming they're valid
     reasoningSummary: z.enum(['auto', 'detailed']).optional(),
     reasoningSummaryFormat: z.enum(['none', 'experimental']).optional(),


### PR DESCRIPTION
## Summary
Adds support for OpenAI's flagship `gpt-5.1-codex-max` model and its exclusive `xhigh` reasoning effort level.

## Changes
- Added `xhigh` to `ReasoningEffort` type across all schema definitions (types, validation, Zod schemas)
- Updated `@openai/codex` dependency to `^0.60.1` for `gpt-5.1-codex-max` support
- Added test coverage for `xhigh` parameter validation
- Updated documentation and examples to reflect new capabilities
- Added `gpt-5.1-codex-max` to package.json keywords

## Model-specific reasoning effort levels
- `gpt-5.1` / `gpt-5.1-codex`: low, medium, high
- `gpt-5.1-codex-max`: low, medium, high, **xhigh** ⭐
- `gpt-5.1-codex-mini`: medium, high

## Testing
- ✅ All 36 tests passing
- ✅ Build successful (ESM + CJS + DTS)
- ✅ Added unit test for `xhigh` validation

## Documentation Updates
- README.md: Updated model list, version requirements, and configuration examples
- docs/ai-sdk-v5/configuration.md: Documented model-specific reasoning effort capabilities
- examples/generate-object-advanced.mjs: Updated to demonstrate `gpt-5.1-codex-max` with `xhigh`

## Breaking Changes
None - purely additive feature. Fully backward compatible.

## Files Changed
9 files modified (+30, -20 lines):
- src/types.ts
- src/codex-cli-language-model.ts
- src/validation.ts
- src/__tests__/validation.test.ts
- README.md
- docs/ai-sdk-v5/configuration.md
- examples/generate-object-advanced.mjs
- package.json / package-lock.json