### PR TITLE
feat: add GPT-5.2 support and 'none' reasoning effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/ben-vargas/ai-sdk-provider-codex-cli/issues)
 [![Latest Release](https://img.shields.io/github/v/release/ben-vargas/ai-sdk-provider-codex-cli?display_name=tag)](https://github.com/ben-vargas/ai-sdk-provider-codex-cli/releases/latest)
 
-A community provider for Vercel AI SDK v6 that uses OpenAI's Codex CLI (non‑interactive `codex exec`) to talk to GPT‑5.1 class models (`gpt-5.1`, the Codex-specific `gpt-5.1-codex`, the flagship `gpt-5.1-codex-max`, and the lightweight `gpt-5.1-codex-mini` slugs) with your ChatGPT Plus/Pro subscription. The provider spawns the Codex CLI process, parses its JSONL output, and adapts it to the AI SDK LanguageModelV3 interface. Legacy GPT-5 / GPT-5-codex slugs remain compatible for existing workflows.
+A community provider for Vercel AI SDK v6 that uses OpenAI's Codex CLI (non‑interactive `codex exec`) to talk to GPT‑5.1 / GPT‑5.2 class models (`gpt-5.1`, `gpt-5.2`, the Codex-specific `gpt-5.1-codex` / `gpt-5.2-codex`, the flagship `*-codex-max`, and the lightweight `*-codex-mini` slugs) with your ChatGPT Plus/Pro subscription. The provider spawns the Codex CLI process, parses its JSONL output, and adapts it to the AI SDK LanguageModelV3 interface. Legacy GPT-5 / GPT-5-codex slugs remain compatible for existing workflows.
 
 - Works with `generateText`, `streamText`, and `generateObject` (native JSON Schema support via `--output-schema`)
 - Uses ChatGPT OAuth from `codex login` (tokens in `~/.codex/auth.json`) or `OPENAI_API_KEY`
@@ -307,7 +307,7 @@ const model = codexCli('gpt-5.1-codex', {
   addDirs: ['../shared'],
 
   // Reasoning & verbosity
-  reasoningEffort: 'medium', // minimal | low | medium | high | xhigh (xhigh only on gpt-5.1-codex-max)
+  reasoningEffort: 'medium', // none | minimal | low | medium | high | xhigh (xhigh on codex-max and newer models that expose it)
   reasoningSummary: 'auto', // auto | detailed (Note: 'concise' and 'none' are rejected by API)
   reasoningSummaryFormat: 'none', // none | experimental
   modelVerbosity: 'high', // low | medium | high

--- a/docs/ai-sdk-v5/configuration.md
+++ b/docs/ai-sdk-v5/configuration.md
@@ -25,9 +25,10 @@ This provider wraps the `codex exec` CLI in non‑interactive mode and maps sett
 
 ### Reasoning & Verbosity
 
-- **`reasoningEffort`** ('minimal' | 'low' | 'medium' | 'high' | 'xhigh'): Controls reasoning depth for reasoning-capable models (o3, o4-mini, the GPT-5.1 family, and legacy GPT-5). Higher effort produces more thorough reasoning at the cost of latency. Maps to `-c model_reasoning_effort=<value>`.
+- **`reasoningEffort`** ('none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'): Controls reasoning depth for reasoning-capable models (o3, o4-mini, the GPT‑5.1/5.2 families, and legacy GPT‑5). Higher effort produces more thorough reasoning at the cost of latency. Maps to `-c model_reasoning_effort=<value>`.
   - Per the Codex CLI model preset definitions (`codex-rs/common/src/model_presets.rs`), `gpt-5.1` and `gpt-5.1-codex` expose `low`, `medium`, and `high`; `gpt-5.1-codex-max` adds `xhigh`; and `gpt-5.1-codex-mini` only surfaces `medium` and `high`.
-  - The older `gpt-5` slug still exposed `minimal`, but the GPT-5.1 family does not; passing `minimal` to a GPT-5.1 slug is rejected server-side.
+  - Per OpenAI API docs, `none` is supported for GPT‑5.1+ reasoning models (and is the default for `gpt-5.1`). Models before GPT‑5.1 default to `medium` and reject `none`. Older GPT‑5 slugs used `minimal`; this provider accepts both as aliases.
+  - `xhigh` is exposed on codex-max models and newer model families that support it.
 - **`reasoningSummary`** ('auto' | 'detailed'): Controls reasoning summary detail level. **Note:** Despite API error messages claiming 'concise' and 'none' are valid, they are rejected with 400 errors. Only 'auto' and 'detailed' work. Maps to `-c model_reasoning_summary=<value>`.
 - **`reasoningSummaryFormat`** ('none' | 'experimental'): Controls reasoning summary format (experimental). Maps to `-c model_reasoning_summary_format=<value>`.
 - **`modelVerbosity`** ('low' | 'medium' | 'high'): Controls output length/detail for GPT-5.1 **non-Codex** models (and legacy GPT-5). Codex-specific slugs (`gpt-5.1-codex`, `gpt-5.1-codex-mini`) ignore this, because the CLI disables verbosity for those model families (`codex-rs/core/src/model_family.rs`). Maps to `-c model_verbosity=<value>` when supported.

--- a/examples/generate-object-advanced.mjs
+++ b/examples/generate-object-advanced.mjs
@@ -21,7 +21,7 @@ const model = codexCli('gpt-5.1-codex-max', {
   approvalMode: 'on-failure',
   sandboxMode: 'workspace-write',
   color: 'never',
-  reasoningEffort: 'xhigh', // gpt-5.1-codex-max only; deeper reasoning for structured outputs
+  reasoningEffort: 'xhigh', // codex-max and newer models that expose xhigh; deeper reasoning for structured outputs
 });
 
 // Example 1: Product comparison with scoring and rationale

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -32,6 +32,12 @@ describe('validateSettings', () => {
     expect(res.errors).toHaveLength(0);
   });
 
+  it('accepts none reasoningEffort (GPT-5.1+)', () => {
+    const res = validateSettings({ reasoningEffort: 'none' });
+    expect(res.valid).toBe(true);
+    expect(res.errors).toHaveLength(0);
+  });
+
   it('accepts addDirs with valid paths', () => {
     const res = validateSettings({ addDirs: ['../shared', '/tmp/lib'] });
     expect(res.valid).toBe(true);

--- a/src/codex-cli-language-model.ts
+++ b/src/codex-cli-language-model.ts
@@ -114,7 +114,7 @@ interface ActiveToolItem {
 
 const codexCliProviderOptionsSchema: z.ZodType<CodexCliProviderOptions> = z
   .object({
-    reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
+    reasoningEffort: z.enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
     reasoningSummary: z.enum(['auto', 'detailed']).optional(),
     reasoningSummaryFormat: z.enum(['none', 'experimental']).optional(),
     textVerbosity: z.enum(['low', 'medium', 'high']).optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,9 @@ export type ApprovalMode = 'untrusted' | 'on-failure' | 'on-request' | 'never';
 
 export type SandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
 
-export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+// 'none' is the newer "no extra reasoning" level for GPT‑5.1+.
+// 'minimal' is retained as a backwards‑compatible alias for older GPT‑5 slugs.
+export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 /**
  * Reasoning summary detail level.
  * Note: The API error messages claim 'concise' and 'none' are valid, but they are
@@ -169,8 +171,8 @@ export interface CodexCliSettings {
    * and legacy GPT-5 slugs). Higher effort produces more thorough reasoning at the cost of latency.
    *
    * Codex CLI model presets currently expose `low`/`medium`/`high` for `gpt-5.1` and `gpt-5.1-codex`.
+   * Per OpenAI API docs, GPT‑5.1+ models support a `none` level (no extra reasoning); older GPT‑5 slugs used `minimal` instead.
    * `gpt-5.1-codex-max` additionally supports `xhigh`. `gpt-5.1-codex-mini` only offers `medium`/`high`.
-   * The legacy `gpt-5` slug still allowed `minimal`, but GPT-5.1 rejects it.
    *
    * Maps to: `-c model_reasoning_effort=<value>`
    * @see https://platform.openai.com/docs/guides/reasoning

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -66,7 +66,7 @@ const settingsSchema = z
     logger: z.union([z.literal(false), loggerFunctionSchema]).optional(),
 
     // NEW: Reasoning & Verbosity
-    reasoningEffort: z.enum(['minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
+    reasoningEffort: z.enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
     // Note: API rejects 'concise' and 'none' despite error messages claiming they're valid
     reasoningSummary: z.enum(['auto', 'detailed']).optional(),
     reasoningSummaryFormat: z.enum(['none', 'experimental']).optional(),


### PR DESCRIPTION
## Summary

Add support for GPT-5.2 models and the `none` reasoning effort level.

## Changes

- Add `'none'` to `ReasoningEffort` type (GPT-5.1+ default, no extra reasoning)
- Keep `'minimal'` as backwards-compatible alias for older GPT-5 slugs
- Update README and docs to mention GPT-5.2 model support (`gpt-5.2`, `gpt-5.2-codex`)
- Add test for `reasoningEffort: 'none'`

## References

- [OpenAI GPT-5.2 docs](https://platform.openai.com/docs/guides/gpt-5-2)
- Codex CLI confirms `gpt-5.2-codex` as default model

## Notes

Cherry-picked from `gpt-5-2-support` branch with README conflict resolved for v6.