### PR TITLE
Fix codexPath resolution for executable Codex CLI installs

### DIFF
--- a/docs/ai-sdk-v5/configuration.md
+++ b/docs/ai-sdk-v5/configuration.md
@@ -5,7 +5,7 @@ This provider wraps the `codex exec` CLI in non‑interactive mode and maps sett
 ## Settings
 
 - `allowNpx` (boolean): If true, runs `npx -y @openai/codex` when Codex isn’t found on PATH.
-- `codexPath` (string): Explicit path to Codex JS entry (`bin/codex.js`), bypassing PATH resolution.
+- `codexPath` (string): Explicit path to Codex CLI executable (e.g. `/opt/homebrew/bin/codex`) or JS entry (`bin/codex.js`), bypassing PATH resolution.
 - `cwd` (string): Working directory for the spawned process.
 - `addDirs` (string[]): Additional directories Codex can read/write. Emits one `--add-dir <path>` per entry (useful in monorepos or when sharing resources across packages).
 - `color` ('always' | 'never' | 'auto'): Controls ANSI color emission.

--- a/src/codex-cli-language-model.ts
+++ b/src/codex-cli-language-model.ts
@@ -140,7 +140,15 @@ function resolveCodexPath(
   explicitPath?: string,
   allowNpx?: boolean,
 ): { cmd: string; args: string[] } {
-  if (explicitPath) return { cmd: 'node', args: [explicitPath] };
+  if (explicitPath) {
+    // `codexPath` may be either a JS entrypoint (e.g. `.../bin/codex.js`) or an executable
+    // (e.g. Homebrew's `/opt/homebrew/bin/codex`). Only force `node` for explicit JS files.
+    const lower = explicitPath.toLowerCase();
+    if (lower.endsWith('.js') || lower.endsWith('.mjs') || lower.endsWith('.cjs')) {
+      return { cmd: 'node', args: [explicitPath] };
+    }
+    return { cmd: explicitPath, args: [] };
+  }
 
   try {
     const req = createRequire(import.meta.url);


### PR DESCRIPTION
This PR fixes a bug where providing an explicit codexPath to the Codex CLI executable (e.g. Homebrew /opt/homebrew/bin/codex) was incorrectly executed via node, causing SyntaxError: `Invalid or unexpected token and stream failures`.

Changes:
- Treat codexPath as either a JS entrypoint (*.cjs, run with node) or a native executable (run directly).
- Add regression tests covering both executable and JS codexPath cases.
- Update configuration docs to clarify that codexPath supports both executable paths and JS entrypoints.