### PR TITLE
Backport: Fix codexPath resolution for executables

### DIFF
--- a/docs/ai-sdk-v5/configuration.md
+++ b/docs/ai-sdk-v5/configuration.md
@@ -5,7 +5,7 @@ This provider wraps the `codex exec` CLI in non‑interactive mode and maps sett
 ## Settings
 
 - `allowNpx` (boolean): If true, runs `npx -y @openai/codex` when Codex isn’t found on PATH.
-- `codexPath` (string): Explicit path to Codex JS entry (`bin/codex.js`), bypassing PATH resolution.
+- `codexPath` (string): Explicit path to Codex CLI executable (e.g. `/opt/homebrew/bin/codex`) or JS entry (`bin/codex.js`), bypassing PATH resolution.
 - `cwd` (string): Working directory for the spawned process.
 - `addDirs` (string[]): Additional directories Codex can read/write. Emits one `--add-dir <path>` per entry (useful in monorepos or when sharing resources across packages).
 - `color` ('always' | 'never' | 'auto'): Controls ANSI color emission.

--- a/src/__tests__/codex-cli-language-model.test.ts
+++ b/src/__tests__/codex-cli-language-model.test.ts
@@ -224,6 +224,67 @@ describe('CodexCliLanguageModel', () => {
     expect(seen.args).toContain('--output-last-message');
   });
 
+  it('spawns an explicit executable codexPath directly (not via node)', async () => {
+    let seen: any = { cmd: '', args: [] as string[] };
+    const lines = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-explicit-exe' }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { item_type: 'assistant_message', text: 'OK' },
+      }),
+    ];
+    (childProc as any).__setSpawnMock((cmd: string, args: string[]) => {
+      seen = { cmd, args };
+      return makeMockSpawn(lines, 0)(cmd, args);
+    });
+
+    const model = new CodexCliLanguageModel({
+      id: 'gpt-5',
+      settings: {
+        codexPath: '/opt/homebrew/bin/codex',
+        color: 'never',
+        skipGitRepoCheck: true,
+      },
+    });
+
+    await model.doGenerate({ prompt: [{ role: 'user', content: 'Hi' }] as any });
+
+    expect(seen.cmd).toBe('/opt/homebrew/bin/codex');
+    expect(seen.args[0]).toBe('exec');
+    expect(seen.args).toContain('--experimental-json');
+  });
+
+  it('spawns an explicit JS codexPath via node', async () => {
+    let seen: any = { cmd: '', args: [] as string[] };
+    const lines = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-explicit-js' }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { item_type: 'assistant_message', text: 'OK' },
+      }),
+    ];
+    (childProc as any).__setSpawnMock((cmd: string, args: string[]) => {
+      seen = { cmd, args };
+      return makeMockSpawn(lines, 0)(cmd, args);
+    });
+
+    const model = new CodexCliLanguageModel({
+      id: 'gpt-5',
+      settings: {
+        codexPath: '/fake/codex.js',
+        color: 'never',
+        skipGitRepoCheck: true,
+      },
+    });
+
+    await model.doGenerate({ prompt: [{ role: 'user', content: 'Hi' }] as any });
+
+    expect(seen.cmd).toBe('node');
+    expect(seen.args[0]).toBe('/fake/codex.js');
+    expect(seen.args).toContain('exec');
+    expect(seen.args).toContain('--experimental-json');
+  });
+
   it('retains user-provided outputLastMessageFile when fallback is used', async () => {
     let outputPath = '';
     const lines = [JSON.stringify({ type: 'thread.started', thread_id: 'thread-last-user' })];

--- a/src/codex-cli-language-model.ts
+++ b/src/codex-cli-language-model.ts
@@ -96,7 +96,15 @@ function resolveCodexPath(
   explicitPath?: string,
   allowNpx?: boolean,
 ): { cmd: string; args: string[] } {
-  if (explicitPath) return { cmd: 'node', args: [explicitPath] };
+  if (explicitPath) {
+    // `codexPath` may be either a JS entrypoint (e.g. `.../bin/codex.js`) or an executable
+    // (e.g. Homebrew's `/opt/homebrew/bin/codex`). Only force `node` for explicit JS files.
+    const lower = explicitPath.toLowerCase();
+    if (lower.endsWith('.js') || lower.endsWith('.mjs') || lower.endsWith('.cjs')) {
+      return { cmd: 'node', args: [explicitPath] };
+    }
+    return { cmd: explicitPath, args: [] };
+  }
 
   try {
     const req = createRequire(import.meta.url);


### PR DESCRIPTION
## Summary

Cherry-pick of #15 for AI SDK v5 branch.

Fixes a bug where providing an explicit `codexPath` to a native executable (e.g., Homebrew's `/opt/homebrew/bin/codex`) was incorrectly executed via `node`, causing `SyntaxError: Invalid or unexpected token`.

## Changes

- Treat `codexPath` as either a JS entrypoint (`*.js`, run with node) or a native executable (run directly)
- Add regression tests covering both executable and JS codexPath cases
- Update configuration docs to clarify both use cases

## Original PR

- #15 by @1WorldCapture

## Test Plan

- [x] All 84 tests pass
- [x] Cherry-pick applied cleanly (no conflicts)