### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2025-12-29
+
+### Fixed
+
+- **codexPath executable support**: Fix bug where providing an explicit `codexPath` to a native executable (e.g., Homebrew's `/opt/homebrew/bin/codex`) was incorrectly executed via `node`, causing `SyntaxError: Invalid or unexpected token`. Now correctly distinguishes between JS entrypoints (`.js`, `.mjs`, `.cjs`) and native executables. (#15, #16)
+
 ## [0.7.1] - 2025-12-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "AI SDK v5 provider for OpenAI Codex CLI with native JSON Schema support",
   "keywords": [
     "ai-sdk",


### PR DESCRIPTION
## Summary

Version bump for 0.7.2 release (AI SDK v5 branch).

## Changes

- Bump version 0.7.1 → 0.7.2
- Add CHANGELOG entry for codexPath executable fix

## Release Notes

### Fixed

- **codexPath executable support**: Fix bug where providing an explicit `codexPath` to a native executable (e.g., Homebrew's `/opt/homebrew/bin/codex`) was incorrectly executed via `node`. (#15, #16)

## Release Order

This PR should be merged and published with `npm publish --tag ai-sdk-v5` **before** the main branch release to ensure main retains the `latest` tag.