### PR TITLE
chore: bump version to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2025-12-29
+
+### Fixed
+
+- **codexPath executable support**: Fix bug where providing an explicit `codexPath` to a native executable (e.g., Homebrew's `/opt/homebrew/bin/codex`) was incorrectly executed via `node`, causing `SyntaxError: Invalid or unexpected token`. Now correctly distinguishes between JS entrypoints (`.js`, `.mjs`, `.cjs`) and native executables. (#15)
+
 ## [1.0.2] - 2025-12-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "AI SDK v6 provider for OpenAI Codex CLI (use ChatGPT Plus/Pro subscription)",
   "keywords": [
     "ai-sdk",


### PR DESCRIPTION
## Summary

Version bump for 1.0.3 release (AI SDK v6 / main branch).

## Changes

- Bump version 1.0.2 → 1.0.3
- Add CHANGELOG entry for codexPath executable fix

## Release Notes

### Fixed

- **codexPath executable support**: Fix bug where providing an explicit `codexPath` to a native executable (e.g., Homebrew's `/opt/homebrew/bin/codex`) was incorrectly executed via `node`. (#15)

## Release Order

1. Merge PR #17 (ai-sdk-v5 bump to 0.7.2)
2. Publish ai-sdk-v5: `npm publish --tag ai-sdk-v5`
3. Merge this PR (main bump to 1.0.3)
4. Publish main: `npm publish` (gets `latest` tag)