### PR TITLE
chore: pin Codex CLI support to 0.130.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-05-15
+
+### Changed
+
+- Update the optional `@openai/codex` dependency from `^0.105.0` to `^0.130.0`, making Codex CLI 0.130.x the validated support baseline for both `codexExec` and `codexAppServer`.
+- Raise app-server minimum/default Codex CLI version references to `0.130.0`.
+- Refresh examples and README snippets to use `gpt-5.5` as the current example model.
+- Refresh AI SDK v6 patch-level lockfile dependencies and related maintenance tooling patches.
+
+### Fixed
+
+- Honor incoming HTTP MCP auth precedence when merging server configs: per-call `bearerToken` and `bearerTokenEnvVar` overrides now remove stale inherited `Authorization` headers while preserving explicit incoming `httpHeaders.Authorization`.
+- Tighten app-server example expectations for newer Codex CLI streaming, raw chunk, logging, long prompt, and multiple shell-tool behavior.
+
 ## [1.1.0] - 2026-02-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/ben-vargas/ai-sdk-provider-codex-cli/issues)
 [![Latest Release](https://img.shields.io/github/v/release/ben-vargas/ai-sdk-provider-codex-cli?display_name=tag)](https://github.com/ben-vargas/ai-sdk-provider-codex-cli/releases/latest)
 
-A community provider for Vercel AI SDK v6 that integrates OpenAI's Codex CLI with GPT‑5.1 / GPT‑5.2 class models (`gpt-5.1`, `gpt-5.2`, the Codex-specific `gpt-5.3-codex` / `gpt-5.2-codex`, the flagship `*-codex-max`, and the lightweight `*-codex-mini` slugs) using your ChatGPT Plus/Pro subscription.
+A community provider for Vercel AI SDK v6 that integrates OpenAI's Codex CLI with current GPT models such as `gpt-5.5`, `gpt-5.2`, and `gpt-5.1`, plus Codex-specific slugs like `gpt-5.3-codex`, `gpt-5.2-codex`, `*-codex-max`, and `*-codex-mini`, using your ChatGPT Plus/Pro subscription.
 
 This package ships two provider modes:
 
@@ -54,7 +54,7 @@ npm i ai ai-sdk-provider-codex-cli
 npm i ai@^5.0.0 ai-sdk-provider-codex-cli@ai-sdk-v5
 ```
 
-> **⚠️ Codex CLI Version**: Requires Codex CLI **>= 0.105.0** for full support of both provider modes (`codexExec` and `codexAppServer`). If you supply your own Codex CLI (global install or custom `codexPath`), check it with `codex --version` and upgrade if needed. The optional dependency `@openai/codex` in this package pulls a compatible version automatically.
+> **⚠️ Codex CLI Version**: Requires the current stable Codex CLI **0.130.x** for full support of both provider modes (`codexExec` and `codexAppServer`). This package pins its optional `@openai/codex` dependency to `^0.130.0`, the latest non-alpha release validated for this maintenance update. If you supply your own Codex CLI (global install or custom `codexPath`), check it with `codex --version` and upgrade if needed.
 >
 > ```bash
 > npm i -g @openai/codex@latest
@@ -68,7 +68,7 @@ npm i ai@^5.0.0 ai-sdk-provider-codex-cli@ai-sdk-v5
 import { generateText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',
@@ -90,14 +90,14 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.105.0',
+    minCodexVersion: '0.130.0',
     autoApprove: false,
     personality: 'pragmatic',
   },
 });
 
 const { textStream } = await streamText({
-  model: provider('gpt-5.3-codex'),
+  model: provider('gpt-5.5'),
   prompt: 'Write two short lines of encouragement.',
 });
 for await (const chunk of textStream) process.stdout.write(chunk);
@@ -107,7 +107,7 @@ await provider.close();
 
 ### App-server stateful threads (optional)
 
-By default, `codexAppServer` is stateless (new ephemeral thread per call). To continue a prior conversation, pass `threadId` in `providerOptions['codex-app-server']`.
+By default, `codexAppServer` is stateless (new ephemeral thread per call). To continue a prior conversation across calls, start a persistent thread and then pass its `threadId` in `providerOptions['codex-app-server']`.
 
 ```js
 import { generateText } from 'ai';
@@ -116,14 +116,17 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 const provider = createCodexAppServer();
 
 const first = await generateText({
-  model: provider('gpt-5.3-codex'),
+  model: provider('gpt-5.5'),
   prompt: 'Start a migration checklist.',
+  providerOptions: {
+    'codex-app-server': { threadMode: 'persistent' },
+  },
 });
 
 const threadId = first.providerMetadata?.['codex-app-server']?.threadId;
 
 const second = await generateText({
-  model: provider('gpt-5.3-codex'),
+  model: provider('gpt-5.5'),
   prompt: 'Continue from step 2.',
   providerOptions: {
     'codex-app-server': { threadId },
@@ -142,7 +145,7 @@ import { codexExec } from 'ai-sdk-provider-codex-cli';
 
 const schema = z.object({ name: z.string(), age: z.number().int() });
 const { object } = await generateObject({
-  model: codexExec('gpt-5.3-codex', { allowNpx: true, skipGitRepoCheck: true }),
+  model: codexExec('gpt-5.5', { allowNpx: true, skipGitRepoCheck: true }),
   schema,
   prompt: 'Generate a small user profile.',
 });
@@ -175,7 +178,7 @@ import { generateText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 import { readFileSync } from 'fs';
 
-const model = codexExec('gpt-5.3-codex', { allowNpx: true, skipGitRepoCheck: true });
+const model = codexExec('gpt-5.5', { allowNpx: true, skipGitRepoCheck: true });
 const imageBuffer = readFileSync('./screenshot.png');
 
 const { text } = await generateText({
@@ -217,7 +220,7 @@ import { streamText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
 const result = await streamText({
-  model: codexExec('gpt-5.3-codex', { allowNpx: true, skipGitRepoCheck: true }),
+  model: codexExec('gpt-5.5', { allowNpx: true, skipGitRepoCheck: true }),
   prompt: 'List files and count lines in the largest one',
 });
 
@@ -253,20 +256,20 @@ Control logging verbosity and integrate with your observability stack:
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
 // Default: warn/error only (clean production output)
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
 });
 
 // Verbose mode: enable debug/info logs for troubleshooting
-const verboseModel = codexExec('gpt-5.3-codex', {
+const verboseModel = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   verbose: true, // Shows all log levels
 });
 
 // Custom logger: integrate with Winston, Pino, Datadog, etc.
-const customModel = codexExec('gpt-5.3-codex', {
+const customModel = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   verbose: true,
@@ -279,7 +282,7 @@ const customModel = codexExec('gpt-5.3-codex', {
 });
 
 // Silent: disable all logging
-const silentModel = codexExec('gpt-5.3-codex', {
+const silentModel = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   logger: false, // No logs at all
@@ -388,7 +391,7 @@ Control reasoning effort, verbosity, and advanced Codex features at model creati
 ```ts
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   addDirs: ['../shared'],
@@ -442,7 +445,7 @@ values take precedence over constructor defaults while leaving other settings in
 import { generateText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   reasoningEffort: 'medium',
   modelVerbosity: 'medium',
@@ -482,7 +485,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 const appServerProvider = createCodexAppServer();
 
 const response = await generateText({
-  model: appServerProvider('gpt-5.3-codex'),
+  model: appServerProvider('gpt-5.5'),
   prompt: 'Continue this task.',
   providerOptions: {
     'codex-app-server': {

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ Provider-specific notes:
   - `npm i -g @openai/codex`
   - `codex login` (or set `OPENAI_API_KEY`)
 - Build this package before running examples: `npm run build`
-- App-server examples require Codex CLI `>= 0.105.0`.
+- App-server examples require Codex CLI `>= 0.130.0`.
 
 ## Run
 

--- a/examples/app-server/README.md
+++ b/examples/app-server/README.md
@@ -5,18 +5,21 @@ These examples use `createCodexAppServer` and a persistent `codex app-server` JS
 ## Notes
 
 - Best for higher-throughput or stateful workflows.
-- Stateful continuation uses `providerOptions['codex-app-server'].threadId`.
+- Stateful continuation starts from a persistent thread and then uses `providerOptions['codex-app-server'].threadId`.
 - Server-initiated JSON-RPC requests can be handled with `serverRequests`.
-- Requires Codex CLI `>= 0.105.0`.
+- Requires Codex CLI `>= 0.130.0`.
 
 ## Thread Lifecycle
 
-- No `threadId` provided:
+- No `threadId` provided in stateless mode:
   - The provider starts an ephemeral thread for the call.
   - It returns the generated `threadId` in `providerMetadata['codex-app-server'].threadId`.
+- `threadMode: 'persistent'` provided:
+  - The provider starts or reuses a persisted thread.
+  - Use the returned `threadId` for explicit multi-turn continuation across separate model instances.
 - `threadId` provided:
   - The provider resumes that thread and appends the new user turn.
-  - Use this for multi-turn memory across separate `generateText`/`streamText` calls.
+  - Use this for multi-turn memory after the original thread was created persistently.
 - Server restart / stale thread:
   - A previously returned `threadId` can become invalid after app-server restarts.
   - In that case, start a new conversation by omitting `threadId`.
@@ -47,13 +50,13 @@ For the repository's app-server smoke test (`src/__tests__/app-server-integratio
 - `CODEX_APP_SERVER_INTEGRATION_CODEX_PATH`
   - Optional path to a specific Codex CLI binary/script to use for the test.
 - `CODEX_APP_SERVER_INTEGRATION_MODEL`
-  - Optional model override (defaults to `gpt-5.3-codex`).
+  - Optional model override (defaults to `gpt-5.5`).
 
 Example:
 
 ```bash
 CODEX_APP_SERVER_INTEGRATION=1 \
-CODEX_APP_SERVER_INTEGRATION_MODEL=gpt-5.3-codex \
+CODEX_APP_SERVER_INTEGRATION_MODEL=gpt-5.5 \
 npx vitest run src/__tests__/app-server-integration.smoke.test.ts
 ```
 

--- a/examples/app-server/abort.mjs
+++ b/examples/app-server/abort.mjs
@@ -2,11 +2,11 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
   });

--- a/examples/app-server/advanced-settings.mjs
+++ b/examples/app-server/advanced-settings.mjs
@@ -2,14 +2,14 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
   async function main() {
     // Example 1: High reasoning effort
     console.log('=== Example 1: Deep Reasoning ===');
-    const deepThinking = appServer('gpt-5.3-codex', {
+    const deepThinking = appServer('gpt-5.5', {
       effort: 'high',
       summary: 'detailed',
     });
@@ -23,7 +23,7 @@ try {
 
     // Example 2: Personality/summary tuning
     console.log('\n=== Example 2: Personality + Summary ===');
-    const withPersonality = appServer('gpt-5.3-codex', {
+    const withPersonality = appServer('gpt-5.5', {
       personality: 'friendly',
       summary: 'concise',
     });
@@ -36,7 +36,7 @@ try {
 
     // Example 3: Generic config overrides
     console.log('\n=== Example 3: Advanced Config ===');
-    const advanced = appServer('gpt-5.3-codex', {
+    const advanced = appServer('gpt-5.5', {
       configOverrides: {
         model_context_window: 200000,
         hide_agent_reasoning: false,
@@ -52,7 +52,7 @@ try {
 
     // Example 4: Combined settings (safe, self-contained)
     console.log('\n=== Example 4: Combined Settings ===');
-    const fullFeatured = appServer('gpt-5.3-codex', {
+    const fullFeatured = appServer('gpt-5.5', {
       effort: 'medium',
       summary: 'detailed',
       personality: 'pragmatic',

--- a/examples/app-server/basic-usage.mjs
+++ b/examples/app-server/basic-usage.mjs
@@ -2,11 +2,11 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
   });

--- a/examples/app-server/check-cli.mjs
+++ b/examples/app-server/check-cli.mjs
@@ -41,7 +41,7 @@ console.log('  app-server command available');
 console.log('\n Running minimal app-server generation...');
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.105.0-alpha.0',
+    minCodexVersion: '0.130.0',
     idleTimeoutMs: 30000,
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
@@ -50,7 +50,7 @@ const provider = createCodexAppServer({
 
 try {
   const { text } = await generateText({
-    model: provider('gpt-5.3-codex'),
+    model: provider('gpt-5.5'),
     prompt: 'Reply with exactly OK.',
   });
   console.log('  App-server generation OK');

--- a/examples/app-server/cmdline-limit-test.mjs
+++ b/examples/app-server/cmdline-limit-test.mjs
@@ -29,7 +29,7 @@ async function main() {
 
   const codex = createCodexAppServer({
     defaultSettings: {
-      minCodexVersion: '0.105.0-alpha.0',
+      minCodexVersion: '0.130.0',
       idleTimeoutMs: 30000,
       cwd: process.cwd(),
       approvalPolicy: 'on-failure',
@@ -40,7 +40,7 @@ async function main() {
     console.log('Calling Codex CLI with long prompt...\n');
 
     const result = await generateText({
-      model: codex('gpt-5.3-codex'),
+      model: codex('gpt-5.5'),
       prompt: longPrompt,
     });
 

--- a/examples/app-server/conversation-history.mjs
+++ b/examples/app-server/conversation-history.mjs
@@ -10,11 +10,11 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
     threadMode: 'persistent',

--- a/examples/app-server/custom-config.mjs
+++ b/examples/app-server/custom-config.mjs
@@ -2,13 +2,13 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
   // Demonstrates custom CWD plus approval/sandbox policy options
 
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     cwd: process.cwd(),
     // Optional app-server style policy overrides:
     // approvalPolicy: 'on-request',

--- a/examples/app-server/error-handling.mjs
+++ b/examples/app-server/error-handling.mjs
@@ -4,11 +4,11 @@ import { generateText } from 'ai';
 import { createCodexAppServer, isAuthenticationError } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
   });

--- a/examples/app-server/expectations.json
+++ b/examples/app-server/expectations.json
@@ -22,7 +22,7 @@
     "basic-usage.mjs": { "mustInclude": ["Result:"] },
     "check-cli.mjs": { "mustInclude": ["app-server"] },
     "conversation-history.mjs": { "mustInclude": ["threadId"] },
-    "generate-object-basic.mjs": { "mustInclude": ["Done"] },
+    "generate-object-basic.mjs": { "mustInclude": ["Done"], "timeoutMs": 90000 },
     "generate-object-constraints.mjs": { "mustInclude": ["Done"] },
     "generate-object-native-schema.mjs": { "mustInclude": ["Native schema showcase complete!"] },
     "generate-object-nested.mjs": { "mustInclude": ["Done"], "timeoutMs": 90000 },
@@ -32,15 +32,22 @@
     },
     "list-models.mjs": { "mustInclude": ["model(s)"] },
     "local-mcp-tool.mjs": { "mustInclude": ["42"] },
-    "long-prompt-test.mjs": { "mustInclude": ["Long Prompt Test"], "timeoutMs": 120000 },
+    "long-prompt-test.mjs": { "mustInclude": ["Long Prompt Test"], "timeoutMs": 180000 },
     "raw-chunks.mjs": { "mustInclude": ["Raw chunks example complete."] },
     "provider-options.mjs": {
       "mustInclude": ["Quick Response", "Deep Analysis", "Provider options example complete."],
       "timeoutMs": 120000
     },
     "session-injection.mjs": { "mustInclude": ["```"] },
-    "streaming-tool-calls.mjs": { "mustInclude": ["Tool"] },
-    "streaming-multiple-tools.mjs": { "mustInclude": ["tool"] },
+    "streaming-tool-calls.mjs": {
+      "mustInclude": ["Tool", "exec"],
+      "mustNotInclude": ["web_search"]
+    },
+    "streaming-multiple-tools.mjs": {
+      "mustInclude": ["Tool", "exec"],
+      "mustNotInclude": ["web_search"],
+      "timeoutMs": 90000
+    },
     "usage-metadata.mjs": { "mustInclude": ["Usage metadata example complete."] }
   }
 }

--- a/examples/app-server/experimental-json-events.mjs
+++ b/examples/app-server/experimental-json-events.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
 /**
- * Experimental JSON Events (Codex CLI v0.2.0+)
+ * App-Server JSON Events (Codex CLI)
  *
- * Demonstrates the new --experimental-json event format.
- * This example shows how the provider parses events like:
- * - session.created
+ * Demonstrates the codex app-server JSON-RPC event stream.
+ * This example shows how the provider maps notifications like:
+ * - thread.started
  * - turn.started / turn.completed
  * - item.started / item.updated / item.completed
  * - Usage tracking from turn.completed events
@@ -15,15 +15,29 @@ import { generateText, streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
-try {
-  console.log(' Experimental JSON Events\n');
-  console.log('This example demonstrates the new event format in v0.2.0.');
-  console.log('Events are parsed from --experimental-json output.\n');
+function getUsageTotals(usage) {
+  const inputTokens =
+    typeof usage.inputTokens === 'number' ? usage.inputTokens : (usage.inputTokens?.total ?? 0);
+  const outputTokens =
+    typeof usage.outputTokens === 'number' ? usage.outputTokens : (usage.outputTokens?.total ?? 0);
+  const totalTokens = usage.totalTokens ?? inputTokens + outputTokens;
+  const cacheRead =
+    usage.cachedInputTokens ??
+    usage.inputTokenDetails?.cacheReadTokens ??
+    usage.inputTokens?.cacheRead;
 
-  const model = appServer('gpt-5.3-codex', {});
+  return { inputTokens, outputTokens, totalTokens, cacheRead };
+}
+
+try {
+  console.log(' App-Server JSON Events\n');
+  console.log('This example demonstrates the codex app-server JSON-RPC event stream.');
+  console.log('Events are parsed from app-server notifications.\n');
+
+  const model = appServer('gpt-5.5', {});
 
   // Example 1: Basic text generation with usage tracking
   async function example1_basicWithUsage() {
@@ -37,11 +51,12 @@ try {
     console.log(' Response:');
     console.log(text);
     console.log('\n Usage (from turn.completed event):');
-    console.log(`   Input tokens:  ${usage.inputTokens.total}`);
-    console.log(`   Output tokens: ${usage.outputTokens.total}`);
-    console.log(`   Total tokens:  ${usage.inputTokens.total + usage.outputTokens.total}`);
-    if (usage.inputTokens.cacheRead) {
-      console.log(`   Cache read:    ${usage.inputTokens.cacheRead}`);
+    const totals = getUsageTotals(usage);
+    console.log(`   Input tokens:  ${totals.inputTokens}`);
+    console.log(`   Output tokens: ${totals.outputTokens}`);
+    console.log(`   Total tokens:  ${totals.totalTokens}`);
+    if (totals.cacheRead) {
+      console.log(`   Cache read:    ${totals.cacheRead}`);
     }
     console.log('\n Response metadata:');
     console.log(`   ID:        ${response.id}`);
@@ -55,17 +70,17 @@ try {
     console.log('2  Understanding Event Flow\n');
 
     console.log('When you call generateText or generateObject, the provider:');
-    console.log('  1. Spawns `codex exec --experimental-json`');
-    console.log('  2. Parses JSONL events from stdout');
+    console.log('  1. Starts or reuses a `codex app-server` JSON-RPC process');
+    console.log('  2. Sends thread/start and turn/start requests');
     console.log('  3. Extracts key data:');
-    console.log('     - session.created     sessionId');
+    console.log('     - thread.started      thread id');
     console.log('     - item.completed      assistant message text');
     console.log('     - turn.completed      usage stats');
     console.log('  4. Maps events to AI SDK format');
     console.log('  5. Returns structured response\n');
 
-    console.log('Event types in --experimental-json:');
-    console.log('   session.created   - Session initialization');
+    console.log('Common app-server event types:');
+    console.log('   thread.started    - Thread initialization');
     console.log('   turn.started      - Turn begins');
     console.log('   turn.completed    - Turn ends (includes usage)');
     console.log('   item.started      - Item begins (command, file change, etc.)');
@@ -90,8 +105,8 @@ try {
     }
 
     console.log('\n\n Stream complete!');
-    console.log('   Note: --experimental-json suppresses deltas,');
-    console.log('   so you typically get a final chunk instead of many small ones.\n');
+    console.log('   Note: app-server event streams may deliver final text');
+    console.log('   chunks instead of many small token-level deltas.\n');
   }
 
   await example1_basicWithUsage();
@@ -100,7 +115,7 @@ try {
 
   console.log(' Event showcase complete!');
   console.log('\n Key Takeaway:');
-  console.log('   The experimental JSON format provides:');
+  console.log('   The app-server JSON-RPC event stream provides:');
   console.log('   - Structured event types');
   console.log('   - Usage tracking');
   console.log('   - Better observability');

--- a/examples/app-server/generate-object-advanced.mjs
+++ b/examples/app-server/generate-object-advanced.mjs
@@ -12,15 +12,15 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
   console.log(' Codex CLI - Advanced Object Generation\n');
 
   // Use the Codex flagship model to exercise extra-high reasoning effort.
-  // Requires codex-cli >= 0.60 for gpt-5.3-codex + xhigh.
-  const model = appServer('gpt-5.3-codex', {
+  // Requires the validated Codex CLI 0.130.x line for gpt-5.5 + xhigh.
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
     effort: 'xhigh', // codex-max and newer models that expose xhigh; deeper reasoning for structured outputs

--- a/examples/app-server/generate-object-basic.mjs
+++ b/examples/app-server/generate-object-basic.mjs
@@ -13,13 +13,13 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
   console.log(' Codex CLI - Basic Object Generation\n');
 
-  const model = appServer('gpt-5.3-codex', {});
+  const model = appServer('gpt-5.5', {});
 
   // Example 1: Simple object with primitives
   async function example1_simpleObject() {

--- a/examples/app-server/generate-object-constraints.mjs
+++ b/examples/app-server/generate-object-constraints.mjs
@@ -11,13 +11,13 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
   console.log(' Codex CLI - Object Generation with Constraints\n');
 
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
   });

--- a/examples/app-server/generate-object-native-schema.mjs
+++ b/examples/app-server/generate-object-native-schema.mjs
@@ -15,7 +15,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
@@ -28,7 +28,7 @@ try {
   console.log('   API-level enforcement (more reliable)');
   console.log('   Guaranteed valid JSON output\n');
 
-  const model = appServer('gpt-5.3-codex', {});
+  const model = appServer('gpt-5.5', {});
 
   // Example 1: Complex nested schema with constraints
   async function example1_complexSchema() {

--- a/examples/app-server/generate-object-nested.mjs
+++ b/examples/app-server/generate-object-nested.mjs
@@ -12,13 +12,13 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
   console.log('  Codex CLI - Nested Object Generation\n');
 
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
     effort: 'low',

--- a/examples/app-server/image-support.mjs
+++ b/examples/app-server/image-support.mjs
@@ -24,7 +24,7 @@ import { generateText, streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
@@ -69,8 +69,8 @@ try {
     );
   }
 
-  // Create model instance - gpt-5.3-codex supports vision/multimodal inputs
-  const model = appServer('gpt-5.3-codex', {
+  // Create model instance - gpt-5.5 supports vision/multimodal inputs
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
   });

--- a/examples/app-server/limitations.mjs
+++ b/examples/app-server/limitations.mjs
@@ -4,11 +4,11 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
   });

--- a/examples/app-server/list-models.mjs
+++ b/examples/app-server/list-models.mjs
@@ -3,7 +3,7 @@
 import { listModels } from 'ai-sdk-provider-codex-cli';
 
 const { models, defaultModel } = await listModels({
-  minCodexVersion: '0.105.0-alpha.0',
+  minCodexVersion: '0.130.0',
 });
 
 console.log(`Found ${models.length} model(s).`);

--- a/examples/app-server/local-mcp-tool.mjs
+++ b/examples/app-server/local-mcp-tool.mjs
@@ -18,7 +18,7 @@ const mathServer = createSdkMcpServer({
 
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.105.0-alpha.0',
+    minCodexVersion: '0.130.0',
     idleTimeoutMs: 30000,
     mcpServers: {
       math: mathServer,
@@ -30,7 +30,7 @@ const provider = createCodexAppServer({
 
 try {
   const result = await generateText({
-    model: provider('gpt-5.3-codex'),
+    model: provider('gpt-5.5'),
     prompt:
       'Use the math MCP tool to compute 41 + 1 and answer with the numeric result and one sentence.',
   });

--- a/examples/app-server/logging-custom-logger.mjs
+++ b/examples/app-server/logging-custom-logger.mjs
@@ -11,8 +11,8 @@
  * - Integrate with existing logging infrastructure
  *
  * Expected output:
- * - Custom prefixed log messages (e.g., "[CUSTOM-DEBUG]")
- * - All log levels when verbose: true
+ * - Custom prefixed log messages (for example, "[CUSTOM-INFO]")
+ * - Provider/app-server diagnostics routed through your logger
  * - Full control over log formatting and routing
  */
 
@@ -20,7 +20,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
@@ -47,12 +47,12 @@ try {
   async function main() {
     console.log('=== Custom Logger Example ===\n');
     console.log('This example shows how to integrate your own logging system.');
-    console.log('All logs will be prefixed with [CUSTOM-*] and include timestamps.\n');
+    console.log('Provider logs will be prefixed with [CUSTOM-*] and include timestamps.\n');
 
     try {
-      // Use custom logger with verbose mode enabled
+      // Use a custom logger with verbose mode enabled.
       const result = streamText({
-        model: appServer('gpt-5.3-codex', {
+        model: appServer('gpt-5.5', {
           approvalPolicy: 'on-failure',
           sandboxPolicy: { type: 'workspaceWrite' },
           verbose: true, // Enable verbose logging to see debug/info
@@ -73,7 +73,7 @@ try {
       console.log('Token usage:', usage);
 
       console.log('\n Custom logger successfully integrated!');
-      console.log('  All logs above are formatted with custom prefixes and timestamps');
+      console.log('  Provider logs above use custom prefixes and timestamps');
       console.log('  You can route these to any logging service (Datadog, Sentry, etc.)');
     } catch (error) {
       console.error('Error:', error);

--- a/examples/app-server/logging-default.mjs
+++ b/examples/app-server/logging-default.mjs
@@ -3,13 +3,14 @@
  *
  * Run: node examples/app-server/logging-default.mjs
  *
- * This example demonstrates the default logging behavior of Codex CLI provider.
- * By default, only warn and error messages are logged.
- * Debug and info messages are suppressed unless verbose mode is enabled.
+ * This example demonstrates the default app-server logging behavior.
+ * By default, routine request debug output is suppressed. You may still see
+ * lifecycle info from the shared app-server client when the process closes.
  *
  * Expected output:
- * - No debug or info logs
- * - Only warn/error logs if something goes wrong
+ * - No debug logs
+ * - Warn/error logs if something goes wrong
+ * - Possible app-server lifecycle info when the client closes
  * - Clean output focused on the actual response
  */
 
@@ -17,21 +18,22 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
   async function main() {
     console.log('=== Default Logging (Non-Verbose Mode) ===\n');
     console.log('Expected behavior:');
-    console.log('- No debug or info logs');
-    console.log('- Only warn/error logs appear if needed');
+    console.log('- No debug logs');
+    console.log('- Warn/error logs appear if needed');
+    console.log('- App-server lifecycle info may appear when the process closes');
     console.log('- Clean output showing just the response\n');
 
     try {
-      // Default logging - only warn/error messages will appear
+      // Default logging suppresses request-level debug output.
       const result = streamText({
-        model: appServer('gpt-5.3-codex', {
+        model: appServer('gpt-5.5', {
           approvalPolicy: 'on-failure',
           sandboxPolicy: { type: 'workspaceWrite' },
         }),
@@ -49,8 +51,8 @@ try {
       const usage = await result.usage;
       console.log('Token usage:', usage);
 
-      console.log('\n Notice: No debug or info logs appeared above');
-      console.log('  This is the default behavior - only essential output is shown');
+      console.log('\n Notice: No debug logs appeared above');
+      console.log('  Routine request tracing is hidden in the default mode');
     } catch (error) {
       console.error('Error:', error);
       console.log('\n Troubleshooting:');

--- a/examples/app-server/logging-disabled.mjs
+++ b/examples/app-server/logging-disabled.mjs
@@ -27,7 +27,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
@@ -41,7 +41,7 @@ try {
     try {
       // Disable all logging
       const result = streamText({
-        model: appServer('gpt-5.3-codex', {
+        model: appServer('gpt-5.5', {
           approvalPolicy: 'on-failure',
           sandboxPolicy: { type: 'workspaceWrite' },
           logger: false, // Disable all logging

--- a/examples/app-server/logging-verbose.mjs
+++ b/examples/app-server/logging-verbose.mjs
@@ -3,13 +3,14 @@
  *
  * Run: node examples/app-server/logging-verbose.mjs
  *
- * This example demonstrates verbose logging mode.
- * When verbose: true is set, you'll see detailed debug and info logs
- * that help you understand what's happening under the hood.
+ * This example demonstrates verbose logging mode for the app-server provider.
+ * The app-server path keeps most protocol traffic structured rather than
+ * logging every request, so verbose mode is most visible through provider
+ * lifecycle and diagnostic messages.
  *
  * Expected output:
- * - Debug logs showing detailed execution trace
- * - Info logs about request/response flow
+ * - Provider/app-server diagnostic logs when available
+ * - Lifecycle info about the app-server process
  * - Warn/error logs if issues occur
  * - Much more detailed output for troubleshooting
  *
@@ -23,21 +24,21 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
   async function main() {
     console.log('=== Verbose Logging Mode ===\n');
     console.log('Expected behavior:');
-    console.log('- Debug logs showing internal details');
-    console.log('- Info logs about execution flow');
-    console.log('- Full visibility into what the provider is doing\n');
+    console.log('- Provider/app-server diagnostic logs when available');
+    console.log('- Lifecycle info about the app-server process');
+    console.log('- More visibility than the disabled logger mode\n');
 
     try {
-      // Enable verbose logging to see debug and info messages
+      // Enable verbose logging to surface provider diagnostics when available.
       const result = streamText({
-        model: appServer('gpt-5.3-codex', {
+        model: appServer('gpt-5.5', {
           approvalPolicy: 'on-failure',
           sandboxPolicy: { type: 'workspaceWrite' },
           verbose: true, // Enable verbose logging
@@ -56,8 +57,8 @@ try {
       const usage = await result.usage;
       console.log('Token usage:', usage);
 
-      console.log('\n Notice: Debug and info logs appeared above');
-      console.log('  Verbose mode provides detailed execution information');
+      console.log('\n Notice: Provider diagnostics may appear above');
+      console.log('  Verbose mode keeps app-server lifecycle messages visible');
       console.log('  This is helpful for development and troubleshooting');
     } catch (error) {
       console.error('Error:', error);

--- a/examples/app-server/long-prompt-test.mjs
+++ b/examples/app-server/long-prompt-test.mjs
@@ -63,11 +63,12 @@ export default function SignIn() {
 \`\`\`
 
 Requirements:
-1. Improve visual design (background depth, card treatment, spacing).
-2. Add a logo/brand placeholder.
-3. Improve button styling and hover/focus states.
-4. Add subtle animation.
-5. Keep Tailwind CSS only.
+1. Do not redesign the whole component.
+2. Prove you received the complete prompt by referencing callbackUrl and Linux.do.
+3. Return exactly three concise lines:
+   LONG_PROMPT_OK
+   callbackUrl + Linux.do
+   one Tailwind improvement under 20 words
 
 Return text only. Do not execute commands. Do not write or modify files.`;
 
@@ -84,7 +85,7 @@ async function main() {
 
   const codex = createCodexAppServer({
     defaultSettings: {
-      minCodexVersion: '0.105.0-alpha.0',
+      minCodexVersion: '0.130.0',
       idleTimeoutMs: 30000,
       cwd: process.cwd(),
       approvalPolicy: 'on-failure',
@@ -97,16 +98,16 @@ async function main() {
     console.log('Calling Codex CLI...\n');
 
     const result = await generateText({
-      model: codex('gpt-5.3-codex'),
+      model: codex('gpt-5.5'),
       system: FRONTEND_PROMPT,
       prompt: USER_PROMPT,
     });
 
     console.log('\n=== Result ===\n');
     console.log(`Response length: ${result.text.length} chars`);
-    console.log(`First 500 chars:\n${result.text.slice(0, 500)}`);
+    console.log(`Response:\n${result.text.trim()}`);
 
-    if (result.text.length < 200) {
+    if (result.text.length < 40) {
       console.log('\nWARNING: Response is suspiciously short.');
       console.log('This may indicate prompt truncation or corruption.');
     }
@@ -125,8 +126,13 @@ async function main() {
       genericResponses.has(normalizedResponse) ||
       (normalizedResponse.length < 120 && /^((i am|i'm)\s+)?ready\b/.test(normalizedResponse));
 
-    if (isGenericResponse || result.text.length < 200) {
-      console.log('\nFAILURE: Got generic/short response instead of actual work.');
+    const containsTransportProof =
+      result.text.includes('LONG_PROMPT_OK') &&
+      normalizedResponse.includes('callbackurl') &&
+      normalizedResponse.includes('linux.do');
+
+    if (isGenericResponse || result.text.length < 40 || !containsTransportProof) {
+      console.log('\nFAILURE: Response did not prove the long prompt was received.');
       process.exitCode = 1;
       return;
     }

--- a/examples/app-server/long-running-tasks.mjs
+++ b/examples/app-server/long-running-tasks.mjs
@@ -8,17 +8,21 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
   });
 
   const ac = new AbortController();
-  const timeout = setTimeout(() => ac.abort(new Error('Timeout after 10s')), 10_000);
+  let abortRequested = false;
+  const timeout = setTimeout(() => {
+    abortRequested = true;
+    ac.abort(new Error('Timeout after 10s'));
+  }, 10_000);
 
   try {
     const { text } = await generateText({
@@ -26,7 +30,14 @@ try {
       prompt: 'Write a detailed 5-paragraph essay on scalable monorepo design.',
       abortSignal: ac.signal,
     });
-    console.log('Result:', text.slice(0, 300) + '...');
+    const preview = text.trim();
+    if (preview.length > 0) {
+      console.log('Result:', preview.slice(0, 300) + (preview.length > 300 ? '...' : ''));
+    } else if (abortRequested || ac.signal.aborted) {
+      console.log('Aborted before text was returned.');
+    } else {
+      console.log('Result: <empty response>');
+    }
   } catch (err) {
     console.error('Aborted:', err?.message || String(err));
   } finally {

--- a/examples/app-server/permissions-and-sandbox.mjs
+++ b/examples/app-server/permissions-and-sandbox.mjs
@@ -11,12 +11,12 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
   async function run(label, settings) {
-    const model = appServer('gpt-5.3-codex', {
+    const model = appServer('gpt-5.5', {
       ...settings,
     });
     const { text } = await generateText({ model, prompt: `Say the mode label: ${label}.` });

--- a/examples/app-server/provider-options.mjs
+++ b/examples/app-server/provider-options.mjs
@@ -2,12 +2,12 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
   async function main() {
-    const model = appServer('gpt-5.3-codex', {
+    const model = appServer('gpt-5.5', {
       effort: 'low',
     });
 
@@ -50,24 +50,18 @@ try {
     });
     console.log(tuned.text);
 
-    console.log('\n=== Per-call MCP override ===');
-    const withMcp = await generateText({
+    console.log('\n=== Per-call Sandbox Override ===');
+    const sandboxed = await generateText({
       model,
-      prompt: 'Reply with exactly: MCP override configured.',
+      prompt: 'Reply with exactly: Sandbox override configured.',
       providerOptions: {
         'codex-app-server': {
-          rmcpClient: true,
-          mcpServers: {
-            docs: {
-              transport: 'http',
-              url: 'https://mcp.example/api',
-              bearerTokenEnvVar: 'MCP_BEARER',
-            },
-          },
+          approvalPolicy: 'never',
+          sandboxPolicy: { type: 'readOnly' },
         },
       },
     });
-    console.log(withMcp.text);
+    console.log(sandboxed.text);
 
     console.log('\nProvider options example complete.');
   }

--- a/examples/app-server/raw-chunks.mjs
+++ b/examples/app-server/raw-chunks.mjs
@@ -2,11 +2,11 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     includeRawChunks: true,
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
@@ -14,6 +14,7 @@ try {
 
   const result = streamText({
     model,
+    includeRawChunks: true,
     prompt: 'Give a short two-sentence summary of why tests matter.',
   });
 
@@ -22,7 +23,7 @@ try {
 
   for await (const part of result.fullStream) {
     if (part.type === 'text-delta') {
-      text += part.textDelta;
+      text += part.text ?? part.delta ?? '';
     }
 
     if (part.type === 'raw') {

--- a/examples/app-server/session-injection.mjs
+++ b/examples/app-server/session-injection.mjs
@@ -5,7 +5,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.105.0-alpha.0',
+    minCodexVersion: '0.130.0',
     idleTimeoutMs: 30000,
     threadMode: 'persistent',
     effort: 'medium',
@@ -15,16 +15,16 @@ const provider = createCodexAppServer({
 
 try {
   const result = streamText({
-    model: provider('gpt-5.3-codex'),
+    model: provider('gpt-5.5'),
     prompt:
-      'Write a tiny Node.js utility that parses CSV with no dependencies. Return code in a single markdown code block only. Do not run commands or write files.',
+      'Write a tiny Node.js function named parseCsvLine that parses one CSV line with no dependencies. Return one markdown code block only. Do not include explanations, usage examples, commands, or file writes.',
     providerOptions: {
       'codex-app-server': {
         onSessionCreated: (session) => {
           // Demonstrates mid-execution guidance while the turn is in-flight.
           setTimeout(() => {
             void session.injectMessage(
-              'Also include basic input validation and one usage example. Keep this as response text only (no command execution, no file writes).',
+              'Update the code block to include basic input validation only. Keep exactly one markdown code block and no explanatory text.',
             );
           }, 500);
         },

--- a/examples/app-server/streaming-multiple-tools.mjs
+++ b/examples/app-server/streaming-multiple-tools.mjs
@@ -1,21 +1,40 @@
 import { streamText } from 'ai';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: {
+    minCodexVersion: '0.130.0',
+    idleTimeoutMs: 30000,
+    cwd: __dirname,
+  },
 });
 
 try {
-  const model = appServer('gpt-5.3-codex', {});
+  const model = appServer('gpt-5.5', {
+    approvalPolicy: 'never',
+    sandboxPolicy: { type: 'readOnly' },
+    configOverrides: {
+      web_search: 'disabled',
+      'tools.web_search': false,
+      'features.web_search_cached': false,
+      'features.web_search_request': false,
+    },
+    developerInstructions:
+      'This example validates shell tool streaming. You must use only the shell exec tool, and you must call it exactly twice before answering. Do not use web search. A final answer without two exec tool calls is invalid.',
+  });
 
   console.log(' Multiple Tool Calls Demo');
-  console.log('Prompt: "List files, then show line count of the largest .mjs file"\n');
+  console.log('Prompt: "Use separate tool calls to list .mjs files, then count the largest one"\n');
 
   try {
     const result = await streamText({
       model,
       prompt:
-        'List all .mjs files in the current directory with their sizes, identify the largest one, then count how many lines it has.',
+        'Use exactly two separate shell exec tool calls and do not use web search. First execute: find . -maxdepth 1 -name "*.mjs" -type f -print. After that result, execute: wc -l ./*.mjs. Do not combine these into one shell command. Finish with a concise summary.',
     });
 
     const toolCalls = [];
@@ -49,7 +68,10 @@ try {
         }
 
         case 'tool-result': {
-          const output = part.result;
+          const output =
+            part.result && typeof part.result === 'object' && part.result.type === 'tool-result'
+              ? part.result.output
+              : part.result;
           const tool = toolCalls.find((t) => t.id === part.toolCallId);
 
           if (tool) {
@@ -118,6 +140,11 @@ try {
     toolCalls.forEach((tool, i) => {
       console.log(`   ${i + 1}. ${tool.name} (${tool.id})`);
     });
+
+    if (toolCalls.length < 2) {
+      console.error(` Expected at least 2 shell exec tool calls, got ${toolCalls.length}.`);
+      process.exitCode = 1;
+    }
   } catch (error) {
     console.error(' Demo failed:', error.message);
     process.exitCode = 1;

--- a/examples/app-server/streaming-tool-calls.mjs
+++ b/examples/app-server/streaming-tool-calls.mjs
@@ -2,11 +2,22 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
-  const model = appServer('gpt-5.3-codex', {});
+  const model = appServer('gpt-5.5', {
+    approvalPolicy: 'never',
+    sandboxPolicy: { type: 'readOnly' },
+    configOverrides: {
+      web_search: 'disabled',
+      'tools.web_search': false,
+      'features.web_search_cached': false,
+      'features.web_search_request': false,
+    },
+    developerInstructions:
+      'This example is about shell tool streaming. Use only the shell exec tool. Do not use web search.',
+  });
 
   console.log(' Codex App Server Tool Streaming Demo');
   console.log('Prompt: "List the current directory with file sizes and summarize"\n');
@@ -15,7 +26,7 @@ try {
     const result = await streamText({
       model,
       prompt:
-        'List the files in the current directory along with their sizes. Print the command output and include a short summary in your final response.',
+        'Use the shell exec tool to list the files in the current directory along with their sizes. Do not use web search. Print the command output and include a short summary in your final response.',
     });
 
     const textBuffer = [];

--- a/examples/app-server/streaming.mjs
+++ b/examples/app-server/streaming.mjs
@@ -2,11 +2,11 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
   });

--- a/examples/app-server/system-messages.mjs
+++ b/examples/app-server/system-messages.mjs
@@ -4,21 +4,20 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
   });
 
-  const messages = [
-    { role: 'system', content: 'You are a terse assistant. Always reply in exactly 3 words.' },
-    { role: 'user', content: 'Describe TypeScript in a nutshell.' },
-  ];
-
-  const { text } = await generateText({ model, messages });
+  const { text } = await generateText({
+    model,
+    system: 'You are a terse assistant. Always reply in exactly 3 words.',
+    prompt: 'Describe TypeScript in a nutshell.',
+  });
   console.log('System-influenced reply:', text);
 } finally {
   await appServer.close();

--- a/examples/app-server/usage-metadata.mjs
+++ b/examples/app-server/usage-metadata.mjs
@@ -2,11 +2,11 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.105.0-alpha.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
 });
 
 try {
-  const model = appServer('gpt-5.3-codex', {
+  const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
   });

--- a/examples/exec/advanced-settings.mjs
+++ b/examples/exec/advanced-settings.mjs
@@ -4,7 +4,7 @@ import { codexExec } from 'ai-sdk-provider-codex-cli';
 async function main() {
   // Example 1: High reasoning effort
   console.log('=== Example 1: Deep Reasoning ===');
-  const deepThinking = codexExec('gpt-5.3-codex', {
+  const deepThinking = codexExec('gpt-5.5', {
     allowNpx: true,
     skipGitRepoCheck: true,
     reasoningEffort: 'high',
@@ -20,7 +20,7 @@ async function main() {
 
   // Example 2: Web search enabled
   console.log('\n=== Example 2: Web Search ===');
-  const withWebSearch = codexExec('gpt-5.3-codex', {
+  const withWebSearch = codexExec('gpt-5.5', {
     allowNpx: true,
     skipGitRepoCheck: true,
     webSearch: true,
@@ -34,7 +34,7 @@ async function main() {
 
   // Example 3: Generic config overrides
   console.log('\n=== Example 3: Advanced Config ===');
-  const advanced = codexExec('gpt-5.3-codex', {
+  const advanced = codexExec('gpt-5.5', {
     allowNpx: true,
     configOverrides: {
       model_context_window: 200000,
@@ -51,24 +51,12 @@ async function main() {
 
   // Example 4: Combined settings
   console.log('\n=== Example 4: All Features ===');
-  const fullFeatured = codexExec('gpt-5.3-codex', {
+  const fullFeatured = codexExec('gpt-5.5', {
     allowNpx: true,
     skipGitRepoCheck: true,
-    rmcpClient: true,
-    mcpServers: {
-      repo: {
-        transport: 'stdio',
-        command: 'node',
-        args: ['tools/repo-mcp.js'],
-      },
-      docs: {
-        transport: 'http',
-        url: 'https://mcp.internal/api',
-        bearerTokenEnvVar: 'MCP_BEARER',
-      },
-    },
-
-    // Custom
+    reasoningEffort: 'medium',
+    reasoningSummary: 'detailed',
+    modelVerbosity: 'medium',
     configOverrides: {
       sandbox_workspace_write: { network_access: true },
     },

--- a/examples/exec/basic-usage.mjs
+++ b/examples/exec/basic-usage.mjs
@@ -1,7 +1,7 @@
 import { generateText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',

--- a/examples/exec/cmdline-limit-test.mjs
+++ b/examples/exec/cmdline-limit-test.mjs
@@ -38,7 +38,7 @@ async function main() {
     console.log('Calling Codex CLI with long prompt...\n');
 
     const result = await generateText({
-      model: codex('gpt-5.3-codex'),
+      model: codex('gpt-5.5'),
       prompt: longPrompt,
     });
 

--- a/examples/exec/conversation-history.mjs
+++ b/examples/exec/conversation-history.mjs
@@ -9,7 +9,7 @@
 import { generateText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',

--- a/examples/exec/custom-config.mjs
+++ b/examples/exec/custom-config.mjs
@@ -3,7 +3,7 @@ import { codexExec } from 'ai-sdk-provider-codex-cli';
 
 // Demonstrates custom CWD and sandbox/approval options
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   cwd: process.cwd(),
   skipGitRepoCheck: true,

--- a/examples/exec/error-handling.mjs
+++ b/examples/exec/error-handling.mjs
@@ -3,7 +3,7 @@
 import { generateText } from 'ai';
 import { codexExec, isAuthenticationError } from 'ai-sdk-provider-codex-cli';
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',

--- a/examples/exec/experimental-json-events.mjs
+++ b/examples/exec/experimental-json-events.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
 /**
- * Experimental JSON Events (Codex CLI v0.2.0+)
+ * Experimental JSON Events (Codex CLI)
  *
- * Demonstrates the new --experimental-json event format.
+ * Demonstrates the --experimental-json event format.
  * This example shows how the provider parses events like:
- * - session.created
+ * - thread.started
  * - turn.started / turn.completed
  * - item.started / item.updated / item.completed
  * - Usage tracking from turn.completed events
@@ -15,15 +15,29 @@ import { generateText, streamText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
 console.log(' Experimental JSON Events\n');
-console.log('This example demonstrates the new event format in v0.2.0.');
+console.log('This example demonstrates the current Codex CLI event format.');
 console.log('Events are parsed from --experimental-json output.\n');
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   dangerouslyBypassApprovalsAndSandbox: true, // For examples only!
   color: 'never',
 });
+
+function getUsageTotals(usage) {
+  const inputTokens =
+    typeof usage.inputTokens === 'number' ? usage.inputTokens : (usage.inputTokens?.total ?? 0);
+  const outputTokens =
+    typeof usage.outputTokens === 'number' ? usage.outputTokens : (usage.outputTokens?.total ?? 0);
+  const totalTokens = usage.totalTokens ?? inputTokens + outputTokens;
+  const cacheRead =
+    usage.cachedInputTokens ??
+    usage.inputTokenDetails?.cacheReadTokens ??
+    usage.inputTokens?.cacheRead;
+
+  return { inputTokens, outputTokens, totalTokens, cacheRead };
+}
 
 // Example 1: Basic text generation with usage tracking
 async function example1_basicWithUsage() {
@@ -37,11 +51,12 @@ async function example1_basicWithUsage() {
   console.log(' Response:');
   console.log(text);
   console.log('\n Usage (from turn.completed event):');
-  console.log(`   Input tokens:  ${usage.inputTokens.total}`);
-  console.log(`   Output tokens: ${usage.outputTokens.total}`);
-  console.log(`   Total tokens:  ${usage.inputTokens.total + usage.outputTokens.total}`);
-  if (usage.inputTokens.cacheRead) {
-    console.log(`   Cache read:    ${usage.inputTokens.cacheRead}`);
+  const totals = getUsageTotals(usage);
+  console.log(`   Input tokens:  ${totals.inputTokens}`);
+  console.log(`   Output tokens: ${totals.outputTokens}`);
+  console.log(`   Total tokens:  ${totals.totalTokens}`);
+  if (totals.cacheRead) {
+    console.log(`   Cache read:    ${totals.cacheRead}`);
   }
   console.log('\n Response metadata:');
   console.log(`   ID:        ${response.id}`);
@@ -58,14 +73,14 @@ async function example2_eventFlow() {
   console.log('  1. Spawns `codex exec --experimental-json`');
   console.log('  2. Parses JSONL events from stdout');
   console.log('  3. Extracts key data:');
-  console.log('     - session.created     sessionId');
+  console.log('     - thread.started      session/thread id');
   console.log('     - item.completed      assistant message text');
   console.log('     - turn.completed      usage stats');
   console.log('  4. Maps events to AI SDK format');
   console.log('  5. Returns structured response\n');
 
   console.log('Event types in --experimental-json:');
-  console.log('   session.created   - Session initialization');
+  console.log('   thread.started    - Thread/session initialization');
   console.log('   turn.started      - Turn begins');
   console.log('   turn.completed    - Turn ends (includes usage)');
   console.log('   item.started      - Item begins (command, file change, etc.)');

--- a/examples/exec/generate-object-advanced.mjs
+++ b/examples/exec/generate-object-advanced.mjs
@@ -14,8 +14,8 @@ import { z } from 'zod';
 console.log(' Codex CLI - Advanced Object Generation\n');
 
 // Use the Codex flagship model to exercise extra-high reasoning effort.
-// Requires codex-cli >= 0.60 for gpt-5.3-codex + xhigh.
-const model = codexExec('gpt-5.3-codex', {
+// Requires the validated Codex CLI 0.130.x line for gpt-5.5 + xhigh.
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',

--- a/examples/exec/generate-object-basic.mjs
+++ b/examples/exec/generate-object-basic.mjs
@@ -14,7 +14,7 @@ import { z } from 'zod';
 
 console.log(' Codex CLI - Basic Object Generation\n');
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   dangerouslyBypassApprovalsAndSandbox: true, // For examples only!

--- a/examples/exec/generate-object-constraints.mjs
+++ b/examples/exec/generate-object-constraints.mjs
@@ -12,7 +12,7 @@ import { z } from 'zod';
 
 console.log(' Codex CLI - Object Generation with Constraints\n');
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',

--- a/examples/exec/generate-object-native-schema.mjs
+++ b/examples/exec/generate-object-native-schema.mjs
@@ -23,7 +23,7 @@ console.log('   100-200 fewer tokens per request');
 console.log('   API-level enforcement (more reliable)');
 console.log('   Guaranteed valid JSON output\n');
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   dangerouslyBypassApprovalsAndSandbox: true, // For examples only!

--- a/examples/exec/generate-object-nested.mjs
+++ b/examples/exec/generate-object-nested.mjs
@@ -13,7 +13,7 @@ import { z } from 'zod';
 
 console.log('  Codex CLI - Nested Object Generation\n');
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',

--- a/examples/exec/image-support.mjs
+++ b/examples/exec/image-support.mjs
@@ -58,8 +58,8 @@ function getMediaType(filePath) {
   return SUPPORTED_EXTENSIONS[ext] || 'image/png';
 }
 
-// Create model instance - gpt-5.3-codex supports vision/multimodal inputs
-const model = codexExec('gpt-5.3-codex', {
+// Create model instance - gpt-5.5 supports vision/multimodal inputs
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',

--- a/examples/exec/limitations.mjs
+++ b/examples/exec/limitations.mjs
@@ -3,7 +3,7 @@
 import { generateText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',

--- a/examples/exec/logging-custom-logger.mjs
+++ b/examples/exec/logging-custom-logger.mjs
@@ -47,7 +47,7 @@ async function main() {
   try {
     // Use custom logger with verbose mode enabled
     const result = streamText({
-      model: codexExec('gpt-5.3-codex', {
+      model: codexExec('gpt-5.5', {
         allowNpx: true,
         skipGitRepoCheck: true,
         approvalMode: 'on-failure',
@@ -81,7 +81,10 @@ async function main() {
   }
 }
 
-main().catch(console.error);
+await main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
 
 // Example: Integration with popular logging libraries
 console.log('\n Integration Examples:\n');

--- a/examples/exec/logging-default.mjs
+++ b/examples/exec/logging-default.mjs
@@ -26,7 +26,7 @@ async function main() {
   try {
     // Default logging - only warn/error messages will appear
     const result = streamText({
-      model: codexExec('gpt-5.3-codex', {
+      model: codexExec('gpt-5.5', {
         allowNpx: true,
         skipGitRepoCheck: true,
         approvalMode: 'on-failure',

--- a/examples/exec/logging-disabled.mjs
+++ b/examples/exec/logging-disabled.mjs
@@ -36,7 +36,7 @@ async function main() {
   try {
     // Disable all logging
     const result = streamText({
-      model: codexExec('gpt-5.3-codex', {
+      model: codexExec('gpt-5.5', {
         allowNpx: true,
         skipGitRepoCheck: true,
         approvalMode: 'on-failure',

--- a/examples/exec/logging-verbose.mjs
+++ b/examples/exec/logging-verbose.mjs
@@ -32,7 +32,7 @@ async function main() {
   try {
     // Enable verbose logging to see debug and info messages
     const result = streamText({
-      model: codexExec('gpt-5.3-codex', {
+      model: codexExec('gpt-5.5', {
         allowNpx: true,
         skipGitRepoCheck: true,
         approvalMode: 'on-failure',

--- a/examples/exec/long-prompt-test.mjs
+++ b/examples/exec/long-prompt-test.mjs
@@ -94,7 +94,7 @@ async function main() {
     console.log('Calling Codex CLI...\n');
 
     const result = await generateText({
-      model: codex('gpt-5.3-codex'),
+      model: codex('gpt-5.5'),
       system: FRONTEND_PROMPT,
       prompt: USER_PROMPT,
     });

--- a/examples/exec/long-running-tasks.mjs
+++ b/examples/exec/long-running-tasks.mjs
@@ -7,7 +7,7 @@
 import { generateText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',
@@ -16,7 +16,11 @@ const model = codexExec('gpt-5.3-codex', {
 });
 
 const ac = new AbortController();
-const timeout = setTimeout(() => ac.abort(new Error('Timeout after 10s')), 10_000);
+let abortRequested = false;
+const timeout = setTimeout(() => {
+  abortRequested = true;
+  ac.abort(new Error('Timeout after 10s'));
+}, 10_000);
 
 try {
   const { text } = await generateText({
@@ -24,7 +28,14 @@ try {
     prompt: 'Write a detailed 5-paragraph essay on scalable monorepo design.',
     abortSignal: ac.signal,
   });
-  console.log('Result:', text.slice(0, 300) + '...');
+  const preview = text.trim();
+  if (preview.length > 0) {
+    console.log('Result:', preview.slice(0, 300) + (preview.length > 300 ? '...' : ''));
+  } else if (abortRequested || ac.signal.aborted) {
+    console.log('Aborted before text was returned.');
+  } else {
+    console.log('Result: <empty response>');
+  }
 } catch (err) {
   console.error('Aborted:', err?.message || String(err));
 } finally {

--- a/examples/exec/permissions-and-sandbox.mjs
+++ b/examples/exec/permissions-and-sandbox.mjs
@@ -11,7 +11,7 @@ import { generateText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
 async function run(label, settings) {
-  const model = codexExec('gpt-5.3-codex', {
+  const model = codexExec('gpt-5.5', {
     allowNpx: true,
     skipGitRepoCheck: true,
     color: 'never',

--- a/examples/exec/provider-options.mjs
+++ b/examples/exec/provider-options.mjs
@@ -2,7 +2,7 @@ import { generateText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
 async function main() {
-  const model = codexExec('gpt-5.3-codex', {
+  const model = codexExec('gpt-5.5', {
     allowNpx: true,
     skipGitRepoCheck: true,
     reasoningEffort: 'medium',
@@ -51,24 +51,20 @@ async function main() {
   });
   console.log(tuned.text);
 
-  console.log('\n=== Per-call MCP override ===');
-  const withMcp = await generateText({
+  console.log('\n=== Per-call Add Directory Override ===');
+  const withAddDir = await generateText({
     model,
-    prompt: 'Ping the docs MCP for /status.',
+    prompt: 'Reply with exactly: Add directory override configured.',
     providerOptions: {
       'codex-cli': {
-        rmcpClient: true,
-        mcpServers: {
-          docs: {
-            transport: 'http',
-            url: 'https://mcp.example/api',
-            bearerTokenEnvVar: 'MCP_BEARER',
-          },
-        },
+        addDirs: ['examples'],
       },
     },
   });
-  console.log(withMcp.text);
+  console.log(withAddDir.text);
 }
 
-main().catch(console.error);
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/exec/streaming-multiple-tools.mjs
+++ b/examples/exec/streaming-multiple-tools.mjs
@@ -1,11 +1,16 @@
 import { streamText } from 'ai';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
-const model = codexExec('gpt-5.3-codex', {
+const exampleCwd = dirname(fileURLToPath(import.meta.url));
+
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   dangerouslyBypassApprovalsAndSandbox: true,
   color: 'never',
+  cwd: exampleCwd,
 });
 
 console.log(' Multiple Tool Calls Demo');
@@ -15,7 +20,7 @@ try {
   const result = await streamText({
     model,
     prompt:
-      'List all .mjs files in the current directory with their sizes, identify the largest one, then count how many lines it has.',
+      'Using shell commands only and without web search, first list all .mjs files in the current directory with their sizes. Then run a separate shell command to count how many lines the largest .mjs file has.',
   });
 
   const toolCalls = [];
@@ -101,13 +106,16 @@ try {
           console.log(''.repeat(60));
         }
 
-        // Usage stats - AI SDK v6 stable uses nested structure
         const usage = part.totalUsage || part.usage;
-        const inputTotal = usage?.inputTokens?.total ?? 0;
-        const outputTotal = usage?.outputTokens?.total ?? 0;
-        console.log(
-          `\n Finished: ${toolCalls.length} tool calls, ${inputTotal} input tokens, ${outputTotal} output tokens`,
-        );
+        const inputTotal =
+          typeof usage?.inputTokens === 'number' ? usage.inputTokens : usage?.inputTokens?.total;
+        const outputTotal =
+          typeof usage?.outputTokens === 'number' ? usage.outputTokens : usage?.outputTokens?.total;
+        const usageSummary =
+          typeof inputTotal === 'number' || typeof outputTotal === 'number'
+            ? `, ${inputTotal ?? 'unknown'} input tokens, ${outputTotal ?? 'unknown'} output tokens`
+            : '';
+        console.log(`\n Finished: ${toolCalls.length} tool calls${usageSummary}`);
         break;
       }
     }

--- a/examples/exec/streaming-tool-calls.mjs
+++ b/examples/exec/streaming-tool-calls.mjs
@@ -1,7 +1,7 @@
 import { streamText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   dangerouslyBypassApprovalsAndSandbox: true,
@@ -80,11 +80,18 @@ try {
         break;
       }
       case 'finish': {
-        // AI SDK v6 stable uses nested usage structure with inputTokens.total, outputTokens.total
         const usage = part.totalUsage || part.usage;
-        const inputTotal = usage?.inputTokens?.total ?? 0;
-        const outputTotal = usage?.outputTokens?.total ?? 0;
-        console.log(`\n Finished (inputTokens=${inputTotal}, outputTokens=${outputTotal})`);
+        const inputTotal =
+          typeof usage?.inputTokens === 'number' ? usage.inputTokens : usage?.inputTokens?.total;
+        const outputTotal =
+          typeof usage?.outputTokens === 'number' ? usage.outputTokens : usage?.outputTokens?.total;
+        if (typeof inputTotal === 'number' || typeof outputTotal === 'number') {
+          console.log(
+            `\n Finished (inputTokens=${inputTotal ?? 'unknown'}, outputTokens=${outputTotal ?? 'unknown'})`,
+          );
+        } else {
+          console.log('\n Finished');
+        }
         break;
       }
       default:

--- a/examples/exec/streaming.mjs
+++ b/examples/exec/streaming.mjs
@@ -1,7 +1,7 @@
 import { streamText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',

--- a/examples/exec/system-messages.mjs
+++ b/examples/exec/system-messages.mjs
@@ -3,7 +3,7 @@
 import { generateText } from 'ai';
 import { codexExec } from 'ai-sdk-provider-codex-cli';
 
-const model = codexExec('gpt-5.3-codex', {
+const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,
   approvalMode: 'on-failure',
@@ -11,10 +11,9 @@ const model = codexExec('gpt-5.3-codex', {
   color: 'never',
 });
 
-const messages = [
-  { role: 'system', content: 'You are a terse assistant. Always reply in exactly 3 words.' },
-  { role: 'user', content: 'Describe TypeScript in a nutshell.' },
-];
-
-const { text } = await generateText({ model, messages });
+const { text } = await generateText({
+  model,
+  system: 'You are a terse assistant. Always reply in exactly 3 words.',
+  prompt: 'Describe TypeScript in a nutshell.',
+});
 console.log('System-influenced reply:', text);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-codex-cli",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.14.0",
-        "@types/node": "20.19.6",
+        "@types/node": "20.19.41",
         "@vitest/coverage-v8": "^3.2.4",
         "ai": "^6.0.3",
         "eslint": "^9.14.0",
         "prettier": "^3.3.3",
-        "tsup": "8.5.0",
+        "tsup": "8.5.1",
         "typescript": "5.6.3",
         "typescript-eslint": "^8.6.0",
         "vitest": "^3.2.4",
@@ -30,22 +30,22 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@openai/codex": "^0.105.0"
+        "@openai/codex": "^0.130.0"
       },
       "peerDependencies": {
         "zod": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.2.tgz",
-      "integrity": "sha512-giJEg9ob45htbu3iautK+2kvplY2JnTj7ir4wZzYSQWvqGatWfBBfDuNCU5wSJt9BCGjymM5ZS9ziD42JGCZBw==",
+      "version": "3.0.114",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.114.tgz",
+      "integrity": "sha512-MqkZ5sd+qiq6RgIxELkoFQXg2/JwK+WCMaot7U+rtrZpWJl3fSyYvc28SC03b256o4F7OXjQtdjTqs81B2w+dA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.0",
-        "@ai-sdk/provider-utils": "4.0.1",
-        "@vercel/oidc": "3.0.5"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
         "node": ">=18"
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.0.tgz",
-      "integrity": "sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -67,14 +67,14 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.1.tgz",
-      "integrity": "sha512-de2v8gH9zj47tRI38oSxhQIewmNc+OZjYIOOaMoVWKL65ERSav2PYYZHPSPCrfOeLMkv+Dyh8Y0QGwkO29wMWQ==",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.0",
+        "@ai-sdk/provider": "3.0.10",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -118,13 +118,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -158,9 +158,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -209,9 +209,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -260,9 +260,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -328,9 +328,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -345,9 +345,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -362,9 +362,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -379,9 +379,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -396,9 +396,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -413,9 +413,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -430,9 +430,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -447,9 +447,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -464,9 +464,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -515,9 +515,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -532,9 +532,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -549,9 +549,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -566,9 +566,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -583,9 +583,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -600,9 +600,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -642,15 +642,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -683,20 +683,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -707,9 +707,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -744,25 +744,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -814,9 +828,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -863,12 +877,132 @@
       }
     },
     "node_modules/@openai/codex": {
-      "optional": true
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0.tgz",
+      "integrity": "sha512-WGDj+RZ3TXWC/7MlwprgLWOqzpwatPIINPhP3IRzHA0ni+o3QZ4i4xrS2uWwGmHUJ395J5JHwoZAAZYyfJyz6w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.130.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.130.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.130.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.130.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.130.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.130.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-arm64.tgz",
+      "integrity": "sha512-R9pkGC7kwC8yQ8el5hvBlmugQlcsG/pHMEFgZluu03X9fD2TezGxdq3KqRDRCZuMYl07ILamVEoqknuJ0cq7MA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-x64.tgz",
+      "integrity": "sha512-gJ+7J8djevgtdra+NgDAiQQPW+O3KTsgGfE3E5dpDfww3zS5OCeV0V2dhxqnJdlOjOSDw99o0P2LqBv19mhpRw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-arm64.tgz",
+      "integrity": "sha512-tFtH0V9/hEI3d9y7zP92BXI9FM4Z3+STNQaOR52Czv18TRtCFUp7CbIUYaToopuq6UBfnE1VKr8RLhwT5FcbmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-x64.tgz",
+      "integrity": "sha512-3VcNlez99xdnEf+kB1IOpWv9fICYV9PiGj4sLCO4TCcShLnyxe+YBGa3poknkvXLnMG0qiN9SMnYS2FGrMxQcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-arm64.tgz",
+      "integrity": "sha512-vdpmiNp57L/arZabltLXn8TyEtNa7W1meOEkr+3R6W/8ZyBt++wuqz1Orv134OT2grrcFJsIVCAIPiqUxCvBkA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.130.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-x64.tgz",
+      "integrity": "sha512-FzMznm7fr5/nbjZgOujZ9Y9AbdGm7ji1FOoWiY3U+srqauvZaTgn6o6aCheSL7kuymu7nTLOO/cAyWV6NuesqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -887,9 +1021,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
-      "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
       "cpu": [
         "arm"
       ],
@@ -901,9 +1035,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
-      "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
       "cpu": [
         "arm64"
       ],
@@ -915,9 +1049,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
-      "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
       "cpu": [
         "arm64"
       ],
@@ -929,9 +1063,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
-      "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
       "cpu": [
         "x64"
       ],
@@ -943,9 +1077,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
-      "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
       "cpu": [
         "arm64"
       ],
@@ -957,9 +1091,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
-      "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
       "cpu": [
         "x64"
       ],
@@ -971,9 +1105,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
-      "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
       "cpu": [
         "arm"
       ],
@@ -985,9 +1119,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
-      "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
       ],
@@ -999,9 +1133,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
-      "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
       "cpu": [
         "arm64"
       ],
@@ -1013,9 +1147,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
-      "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
       ],
@@ -1027,9 +1161,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
-      "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
       ],
@@ -1041,9 +1189,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
-      "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
       ],
@@ -1055,9 +1217,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
-      "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
       "cpu": [
         "riscv64"
       ],
@@ -1069,9 +1231,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
-      "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
       ],
@@ -1083,9 +1245,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
-      "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
       "cpu": [
         "s390x"
       ],
@@ -1097,9 +1259,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
       "cpu": [
         "x64"
       ],
@@ -1111,9 +1273,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
-      "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
       ],
@@ -1124,10 +1286,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
-      "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
       "cpu": [
         "arm64"
       ],
@@ -1139,9 +1315,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
-      "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
       "cpu": [
         "arm64"
       ],
@@ -1153,9 +1329,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
-      "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
       "cpu": [
         "ia32"
       ],
@@ -1167,9 +1343,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
       "cpu": [
         "x64"
       ],
@@ -1181,9 +1357,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
-      "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
       "cpu": [
         "x64"
       ],
@@ -1219,9 +1395,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1233,9 +1409,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.6.tgz",
-      "integrity": "sha512-uYssdp9z5zH5GQ0L4zEJ2ZuavYsJwkozjiUzCRfGtaaQcyjAMJ34aP8idv61QlqTozu6kudyr6JMq9Chf09dfA==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1243,20 +1419,20 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.1.tgz",
-      "integrity": "sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.50.1",
-        "@typescript-eslint/type-utils": "8.50.1",
-        "@typescript-eslint/utils": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1266,9 +1442,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.50.1",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.59.3",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -1282,17 +1458,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.1.tgz",
-      "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.50.1",
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1302,20 +1478,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.1.tgz",
-      "integrity": "sha512-E1ur1MCVf+YiP89+o4Les/oBAVzmSbeRB0MQLfSlYtbWU17HPxZ6Bhs5iYmKZRALvEuBoXIZMOIRRc/P++Ortg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.50.1",
-        "@typescript-eslint/types": "^8.50.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1325,18 +1501,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.1.tgz",
-      "integrity": "sha512-mfRx06Myt3T4vuoHaKi8ZWNTPdzKPNBhiblze5N50//TSHOAQQevl/aolqA/BcqqbJ88GUnLqjjcBc8EWdBcVw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1347,9 +1523,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.1.tgz",
-      "integrity": "sha512-ooHmotT/lCWLXi55G4mvaUF60aJa012QzvLK0Y+Mp4WdSt17QhMhWOaBWeGTFVkb2gDgBe19Cxy1elPXylslDw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1360,21 +1536,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.1.tgz",
-      "integrity": "sha512-7J3bf022QZE42tYMO6SL+6lTPKFk/WphhRPe9Tw/el+cEwzLz1Jjz2PX3GtGQVxooLDKeMVmMt7fWpYRdG5Etg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1",
-        "@typescript-eslint/utils": "8.50.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1384,14 +1560,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.1.tgz",
-      "integrity": "sha512-v5lFIS2feTkNyMhd7AucE/9j/4V9v5iIbpVRncjk/K0sQ6Sb+Np9fgYS/63n6nwqahHQvbmujeBL7mp07Q9mlA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1403,21 +1579,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.1.tgz",
-      "integrity": "sha512-woHPdW+0gj53aM+cxchymJCrh0cyS7BTIdcDxWUNsclr9VDkOSbqC13juHzxOmQ22dDkMZEpZB+3X1WpUvzgVQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.50.1",
-        "@typescript-eslint/tsconfig-utils": "8.50.1",
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1",
-        "debug": "^4.3.4",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1427,46 +1603,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.1.tgz",
-      "integrity": "sha512-lCLp8H1T9T7gPbEuJSnHwnSuO9mDf8mfK/Nion5mZmiEaQD9sWf9W4dfeFqRyqRjF06/kBuTmAqcs9sewM2NbQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.50.1",
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1476,19 +1665,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.1.tgz",
-      "integrity": "sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.1",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.59.3",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1498,10 +1687,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@vercel/oidc": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz",
-      "integrity": "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1658,9 +1860,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1681,16 +1883,16 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.3.tgz",
-      "integrity": "sha512-OOo+/C+sEyscoLnbY3w42vjQDICioVNyS+F+ogwq6O5RJL/vgWGuiLzFwuP7oHTeni/MkmX8tIge48GTdaV7QQ==",
+      "version": "6.0.182",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.182.tgz",
+      "integrity": "sha512-ooJdziFjYrYRcsCx107roqA8gDTI3P82nUfroNWIhVvwrkYzEN3W1l50YK+XNqkUew8AiimaW0/SLBewRXMuHQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.2",
-        "@ai-sdk/provider": "3.0.0",
-        "@ai-sdk/provider-utils": "4.0.1",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "3.0.114",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "^1.9.0"
       },
       "engines": {
         "node": ">=18"
@@ -1700,9 +1902,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1770,15 +1972,15 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
-      "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
-        "js-tokens": "^9.0.1"
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1789,9 +1991,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1870,9 +2072,9 @@
       }
     },
     "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2021,9 +2223,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2034,32 +2236,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2076,25 +2278,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -2113,7 +2315,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2184,9 +2386,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2240,9 +2442,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2354,9 +2556,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2396,6 +2598,7 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2427,9 +2630,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2437,13 +2640,13 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2640,9 +2843,9 @@
       }
     },
     "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2769,13 +2972,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2829,9 +3025,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2842,26 +3038,26 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mlly": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "pathe": "^2.0.3",
         "pkg-types": "^1.3.1",
-        "ufo": "^1.6.1"
+        "ufo": "^1.6.3"
       }
     },
     "node_modules/ms": {
@@ -2884,9 +3080,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -3051,9 +3247,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3086,9 +3282,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -3168,9 +3364,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3218,9 +3414,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
-      "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3234,35 +3430,45 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.54.0",
-        "@rollup/rollup-android-arm64": "4.54.0",
-        "@rollup/rollup-darwin-arm64": "4.54.0",
-        "@rollup/rollup-darwin-x64": "4.54.0",
-        "@rollup/rollup-freebsd-arm64": "4.54.0",
-        "@rollup/rollup-freebsd-x64": "4.54.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.54.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.54.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.54.0",
-        "@rollup/rollup-linux-arm64-musl": "4.54.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.54.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.54.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-musl": "4.54.0",
-        "@rollup/rollup-openharmony-arm64": "4.54.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.54.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.54.0",
-        "@rollup/rollup-win32-x64-gnu": "4.54.0",
-        "@rollup/rollup-win32-x64-msvc": "4.54.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3316,17 +3522,13 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -3418,13 +3620,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -3483,6 +3685,13 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -3520,41 +3729,54 @@
       }
     },
     "node_modules/test-exclude": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
-      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^10.4.1",
-        "minimatch": "^9.0.4"
+        "minimatch": "^10.2.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3598,14 +3820,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3644,16 +3866,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -3665,9 +3877,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.2.0.tgz",
-      "integrity": "sha512-L6f5oQRAoLU1RwXz0Ab9mxsE7LtxeVB6AIR1lpkZMsOyg/JXeaxBaXa/FVCBZyNr9S9I4wkHrlZTklX+im+WMw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3685,9 +3897,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/tsup": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.0.tgz",
-      "integrity": "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3696,14 +3908,14 @@
         "chokidar": "^4.0.3",
         "consola": "^3.4.0",
         "debug": "^4.4.0",
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.0",
         "fix-dts-default-cjs-exports": "^1.0.0",
         "joycon": "^3.1.1",
         "picocolors": "^1.1.1",
         "postcss-load-config": "^6.0.1",
         "resolve-from": "^5.0.0",
         "rollup": "^4.34.8",
-        "source-map": "0.8.0-beta.0",
+        "source-map": "^0.7.6",
         "sucrase": "^3.35.0",
         "tinyexec": "^0.3.2",
         "tinyglobby": "^0.2.11",
@@ -3775,16 +3987,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.50.1.tgz",
-      "integrity": "sha512-ytTHO+SoYSbhAH9CrYnMhiLx8To6PSSvqnvXyPUgPETCvB6eBKmTI9w6XMPS3HsBRGkwTVBX+urA8dYQx6bHfQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.50.1",
-        "@typescript-eslint/parser": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1",
-        "@typescript-eslint/utils": "8.50.1"
+        "@typescript-eslint/eslint-plugin": "8.59.3",
+        "@typescript-eslint/parser": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3794,14 +4006,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3823,9 +4035,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
-      "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3920,490 +4132,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.2",
-        "@esbuild/android-arm": "0.27.2",
-        "@esbuild/android-arm64": "0.27.2",
-        "@esbuild/android-x64": "0.27.2",
-        "@esbuild/darwin-arm64": "0.27.2",
-        "@esbuild/darwin-x64": "0.27.2",
-        "@esbuild/freebsd-arm64": "0.27.2",
-        "@esbuild/freebsd-x64": "0.27.2",
-        "@esbuild/linux-arm": "0.27.2",
-        "@esbuild/linux-arm64": "0.27.2",
-        "@esbuild/linux-ia32": "0.27.2",
-        "@esbuild/linux-loong64": "0.27.2",
-        "@esbuild/linux-mips64el": "0.27.2",
-        "@esbuild/linux-ppc64": "0.27.2",
-        "@esbuild/linux-riscv64": "0.27.2",
-        "@esbuild/linux-s390x": "0.27.2",
-        "@esbuild/linux-x64": "0.27.2",
-        "@esbuild/netbsd-arm64": "0.27.2",
-        "@esbuild/netbsd-x64": "0.27.2",
-        "@esbuild/openbsd-arm64": "0.27.2",
-        "@esbuild/openbsd-x64": "0.27.2",
-        "@esbuild/openharmony-arm64": "0.27.2",
-        "@esbuild/sunos-x64": "0.27.2",
-        "@esbuild/win32-arm64": "0.27.2",
-        "@esbuild/win32-ia32": "0.27.2",
-        "@esbuild/win32-x64": "0.27.2"
-      }
-    },
     "node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -4475,25 +4203,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/which": {
@@ -4648,9 +4357,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
-      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "language-model",
     "gpt-5",
     "gpt-5.1",
-    "gpt-5.3-codex",
+    "gpt-5.5",
     "gpt-5.2-codex-max",
     "provider"
   ],
@@ -67,16 +67,16 @@
     "jsonc-parser": "^3.3.1"
   },
   "optionalDependencies": {
-    "@openai/codex": "^0.105.0"
+    "@openai/codex": "^0.130.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",
-    "@types/node": "20.19.6",
+    "@types/node": "20.19.41",
     "@vitest/coverage-v8": "^3.2.4",
     "ai": "^6.0.3",
     "eslint": "^9.14.0",
     "prettier": "^3.3.3",
-    "tsup": "8.5.0",
+    "tsup": "8.5.1",
     "typescript": "5.6.3",
     "vitest": "^3.2.4",
     "typescript-eslint": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "AI SDK v6 provider for OpenAI Codex CLI (use ChatGPT Plus/Pro subscription)",
   "keywords": [
     "ai-sdk",

--- a/src/__tests__/app-server-integration.smoke.test.ts
+++ b/src/__tests__/app-server-integration.smoke.test.ts
@@ -14,7 +14,7 @@ describeIntegration('app-server integration smoke', () => {
       const modelId = process.env.CODEX_APP_SERVER_INTEGRATION_MODEL ?? 'gpt-5.3-codex';
       const provider = createCodexAppServer({
         defaultSettings: {
-          minCodexVersion: '0.105.0',
+          minCodexVersion: '0.130.0',
           connectionTimeoutMs: 60_000,
           codexPath,
           approvalPolicy: 'never',
@@ -26,6 +26,7 @@ describeIntegration('app-server integration smoke', () => {
         const first = await generateText({
           model: provider(modelId),
           prompt: 'Reply with one short word.',
+          providerOptions: { 'codex-app-server': { threadMode: 'persistent' } },
         });
         expect(first.text.trim().length).toBeGreaterThan(0);
 

--- a/src/__tests__/app-server-provider.test.ts
+++ b/src/__tests__/app-server-provider.test.ts
@@ -9,7 +9,7 @@ import { createSdkMcpServer, tool } from '../tools/index.js';
 describe('createCodexAppServer', () => {
   it('creates language model instances', () => {
     const provider = createCodexAppServer({
-      defaultSettings: { minCodexVersion: '0.105.0', personality: 'pragmatic' },
+      defaultSettings: { minCodexVersion: '0.130.0', personality: 'pragmatic' },
     });
 
     const model: any = provider('gpt-5.3-codex');
@@ -97,7 +97,7 @@ describe('createCodexAppServer', () => {
   it('uses a distinct RPC client when per-model transport settings differ', async () => {
     const provider = createCodexAppServer({
       defaultSettings: {
-        minCodexVersion: '0.105.0',
+        minCodexVersion: '0.130.0',
         requestTimeoutMs: 10_000,
       },
     });
@@ -124,7 +124,7 @@ describe('createCodexAppServer', () => {
   it('reuses RPC client when only non-transport model settings differ', async () => {
     const provider = createCodexAppServer({
       defaultSettings: {
-        minCodexVersion: '0.105.0',
+        minCodexVersion: '0.130.0',
       },
     });
 
@@ -143,7 +143,7 @@ describe('createCodexAppServer', () => {
   it('reuses persistent model instances for identical model + settings', async () => {
     const provider = createCodexAppServer({
       defaultSettings: {
-        minCodexVersion: '0.105.0',
+        minCodexVersion: '0.130.0',
       },
     });
 
@@ -175,7 +175,7 @@ describe('createCodexAppServer', () => {
 
     const provider = createCodexAppServer({
       defaultSettings: {
-        minCodexVersion: '0.105.0',
+        minCodexVersion: '0.130.0',
         threadMode: 'persistent',
         mcpServers: {
           math: sdkServer,
@@ -219,7 +219,7 @@ describe('createCodexAppServer', () => {
     };
 
     const provider = createCodexAppServer({
-      defaultSettings: { minCodexVersion: '0.105.0' },
+      defaultSettings: { minCodexVersion: '0.130.0' },
     });
 
     const first = provider('gpt-5.3-codex', createSettings());
@@ -253,7 +253,7 @@ describe('createCodexAppServer', () => {
     };
 
     const provider = createCodexAppServer({
-      defaultSettings: { minCodexVersion: '0.105.0' },
+      defaultSettings: { minCodexVersion: '0.130.0' },
     });
 
     const first = provider('gpt-5.3-codex', createSettings());
@@ -285,7 +285,7 @@ describe('createCodexAppServer', () => {
     };
 
     const provider = createCodexAppServer({
-      defaultSettings: { minCodexVersion: '0.105.0' },
+      defaultSettings: { minCodexVersion: '0.130.0' },
     });
 
     const first = provider('gpt-5.3-codex', createSettings(0));
@@ -311,7 +311,7 @@ describe('createCodexAppServer', () => {
     });
 
     const provider = createCodexAppServer({
-      defaultSettings: { minCodexVersion: '0.105.0' },
+      defaultSettings: { minCodexVersion: '0.130.0' },
     });
 
     const first = provider('gpt-5.3-codex', {
@@ -341,7 +341,7 @@ describe('createCodexAppServer', () => {
   it('retains persistent model cache entries until provider.close()', async () => {
     const provider = createCodexAppServer({
       defaultSettings: {
-        minCodexVersion: '0.105.0',
+        minCodexVersion: '0.130.0',
       },
     });
 

--- a/src/__tests__/app-server-rpc-client.test.ts
+++ b/src/__tests__/app-server-rpc-client.test.ts
@@ -77,7 +77,7 @@ function createMockProcess(
           `${JSON.stringify({
             id: message.id,
             result: {
-              userAgent: options.userAgent ?? 'codex-cli 0.105.0',
+              userAgent: options.userAgent ?? 'codex-cli 0.130.0',
               capabilities: options.initializeCapabilities ?? null,
             },
           })}\n`,
@@ -734,21 +734,21 @@ describe('AppServerRpcClient', () => {
   });
 
   it('enforces min version against prerelease builds', async () => {
-    const { child } = createMockProcess({ userAgent: 'codex-cli 0.105.0-alpha.17' });
+    const { child } = createMockProcess({ userAgent: 'codex-cli 0.130.0-alpha.17' });
     setSpawnMock(() => child);
 
     const client = new AppServerRpcClient({
-      settings: { minCodexVersion: '0.105.0' },
+      settings: { minCodexVersion: '0.130.0' },
     });
 
     await expect(client.ensureReady()).rejects.toThrow(
-      "codex app-server version '0.105.0-alpha.17' is below required minimum '0.105.0'.",
+      "codex app-server version '0.130.0-alpha.17' is below required minimum '0.130.0'.",
     );
   });
 
   it('kills spawned process and recovers cleanly after initialization failure', async () => {
     const first = createMockProcess({ userAgent: 'codex-cli 0.104.9' });
-    const second = createMockProcess({ userAgent: 'codex-cli 0.105.0' });
+    const second = createMockProcess({ userAgent: 'codex-cli 0.130.0' });
     let spawns = 0;
     setSpawnMock(() => {
       spawns += 1;
@@ -756,11 +756,11 @@ describe('AppServerRpcClient', () => {
     });
 
     const client = new AppServerRpcClient({
-      settings: { minCodexVersion: '0.105.0' },
+      settings: { minCodexVersion: '0.130.0' },
     });
 
     await expect(client.ensureReady()).rejects.toThrow(
-      "codex app-server version '0.104.9' is below required minimum '0.105.0'.",
+      "codex app-server version '0.104.9' is below required minimum '0.130.0'.",
     );
     expect(first.child.kill).toHaveBeenCalledWith('SIGTERM');
 

--- a/src/__tests__/codex-cli-language-model.test.ts
+++ b/src/__tests__/codex-cli-language-model.test.ts
@@ -961,6 +961,11 @@ describe('CodexCliLanguageModel', () => {
                 bearerTokenEnvVar: 'MCP_TOKEN',
                 httpHeaders: { 'x-debug': '1' },
               },
+              direct: {
+                transport: 'http',
+                url: 'https://direct.example',
+                bearerToken: 'DIRECT_TOKEN',
+              },
             },
           },
         },
@@ -974,6 +979,13 @@ describe('CodexCliLanguageModel', () => {
       expect(argsCaptured).toContain('mcp_servers.remote.url=https://mcp.example');
       expect(argsCaptured).toContain('mcp_servers.remote.bearer_token_env_var=MCP_TOKEN');
       expect(argsCaptured).toContain('mcp_servers.remote.http_headers.x-debug=1');
+      expect(argsCaptured).toContain('mcp_servers.direct.url=https://direct.example');
+      expect(argsCaptured).toContain(
+        'mcp_servers.direct.http_headers.Authorization=Bearer DIRECT_TOKEN',
+      );
+      expect(argsCaptured.some((arg) => arg.includes('mcp_servers.direct.bearer_token='))).toBe(
+        false,
+      );
     });
 
     it('allows clearing stdio MCP args and tool lists with empty arrays', async () => {
@@ -1129,6 +1141,11 @@ describe('CodexCliLanguageModel', () => {
       expect(
         argsCaptured.some((arg) =>
           arg.includes('mcp_servers.remote.bearer_token=base-token-secret'),
+        ),
+      ).toBe(false);
+      expect(
+        argsCaptured.some((arg) =>
+          arg.includes('mcp_servers.remote.http_headers.Authorization=Bearer base-token-secret'),
         ),
       ).toBe(false);
     });

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -40,7 +40,7 @@ describe('errors', () => {
   it('unsupported feature helper is detected', () => {
     const err = new UnsupportedFeatureError({
       feature: 'model/list',
-      minCodexVersion: '0.105.0',
+      minCodexVersion: '0.130.0',
       serverVersion: '0.104.0',
     });
     expect(isUnsupportedFeatureError(err)).toBe(true);

--- a/src/__tests__/exec-language-model.test.ts
+++ b/src/__tests__/exec-language-model.test.ts
@@ -961,6 +961,11 @@ describe('ExecLanguageModel', () => {
                 bearerTokenEnvVar: 'MCP_TOKEN',
                 httpHeaders: { 'x-debug': '1' },
               },
+              direct: {
+                transport: 'http',
+                url: 'https://direct.example',
+                bearerToken: 'DIRECT_TOKEN',
+              },
             },
           },
         },
@@ -974,6 +979,13 @@ describe('ExecLanguageModel', () => {
       expect(argsCaptured).toContain('mcp_servers.remote.url=https://mcp.example');
       expect(argsCaptured).toContain('mcp_servers.remote.bearer_token_env_var=MCP_TOKEN');
       expect(argsCaptured).toContain('mcp_servers.remote.http_headers.x-debug=1');
+      expect(argsCaptured).toContain('mcp_servers.direct.url=https://direct.example');
+      expect(argsCaptured).toContain(
+        'mcp_servers.direct.http_headers.Authorization=Bearer DIRECT_TOKEN',
+      );
+      expect(argsCaptured.some((arg) => arg.includes('mcp_servers.direct.bearer_token='))).toBe(
+        false,
+      );
     });
 
     it('allows clearing stdio MCP args and tool lists with empty arrays', async () => {
@@ -1129,6 +1141,11 @@ describe('ExecLanguageModel', () => {
       expect(
         argsCaptured.some((arg) =>
           arg.includes('mcp_servers.remote.bearer_token=base-token-secret'),
+        ),
+      ).toBe(false);
+      expect(
+        argsCaptured.some((arg) =>
+          arg.includes('mcp_servers.remote.http_headers.Authorization=Bearer base-token-secret'),
         ),
       ).toBe(false);
     });

--- a/src/__tests__/shared-utils.test.ts
+++ b/src/__tests__/shared-utils.test.ts
@@ -160,6 +160,12 @@ describe('shared-utils', () => {
           url: 'https://mcp.example.com',
           bearerTokenEnvVar: 'TOKEN_ENV',
         },
+        direct: {
+          transport: 'http',
+          url: 'https://direct.example.com',
+          bearerToken: 'DIRECT_TOKEN',
+          httpHeaders: { 'x-debug': '1' },
+        },
       },
       true,
     );
@@ -169,6 +175,12 @@ describe('shared-utils', () => {
     expect(overrides['mcp_servers.local.args']).toEqual(['server.js']);
     expect(overrides['mcp_servers.remote.url']).toBe('https://mcp.example.com');
     expect(overrides['mcp_servers.remote.bearer_token_env_var']).toBe('TOKEN_ENV');
+    expect(overrides['mcp_servers.direct.url']).toBe('https://direct.example.com');
+    expect(overrides['mcp_servers.direct.bearer_token']).toBeUndefined();
+    expect(overrides['mcp_servers.direct.http_headers']).toEqual({
+      'x-debug': '1',
+      Authorization: 'Bearer DIRECT_TOKEN',
+    });
   });
 
   it('rejects invalid MCP server names consistently during merge and override mapping', () => {

--- a/src/__tests__/shared-utils.test.ts
+++ b/src/__tests__/shared-utils.test.ts
@@ -4,6 +4,7 @@ import {
   isPlainObject,
   mapCodexCliFinishReason,
   mapUnsupportedSettingsWarnings,
+  mcpHttpHeadersWithBearerToken,
   mcpServersToConfigOverrides,
   mergeSingleMcpServer,
   mergeStringRecord,
@@ -106,6 +107,62 @@ describe('shared-utils', () => {
       enabledTools: undefined,
       disabledTools: undefined,
     });
+  });
+
+  it('lets incoming HTTP MCP bearerToken replace inherited Authorization header', () => {
+    const merged = mergeSingleMcpServer(
+      {
+        transport: 'http',
+        url: 'https://old',
+        httpHeaders: {
+          authorization: 'Bearer old-token',
+          A: '1',
+        },
+      },
+      {
+        transport: 'http',
+        url: 'https://new',
+        bearerToken: 'new-token',
+        httpHeaders: { B: '2' },
+      },
+    );
+
+    expect(merged.transport).toBe('http');
+    if (merged.transport !== 'http') throw new Error('Expected HTTP MCP server');
+
+    expect(merged.httpHeaders).toEqual({ A: '1', B: '2' });
+    expect(mcpHttpHeadersWithBearerToken(merged)).toEqual({
+      A: '1',
+      B: '2',
+      Authorization: 'Bearer new-token',
+    });
+  });
+
+  it('removes inherited HTTP MCP Authorization header when bearerTokenEnvVar replaces auth', () => {
+    const merged = mergeSingleMcpServer(
+      {
+        transport: 'http',
+        url: 'https://old',
+        bearerToken: 'old-token',
+        httpHeaders: {
+          AUTHORIZATION: 'Bearer stale-token',
+          A: '1',
+        },
+      },
+      {
+        transport: 'http',
+        url: 'https://new',
+        bearerTokenEnvVar: 'NEW_TOKEN_ENV',
+        httpHeaders: { B: '2' },
+      },
+    );
+
+    expect(merged.transport).toBe('http');
+    if (merged.transport !== 'http') throw new Error('Expected HTTP MCP server');
+
+    expect(merged.bearerToken).toBeUndefined();
+    expect(merged.bearerTokenEnvVar).toBe('NEW_TOKEN_ENV');
+    expect(mcpHttpHeadersWithBearerToken(merged)).toEqual({ A: '1', B: '2' });
   });
 
   it('mergeStringRecord handles empty override as clear', () => {

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -60,7 +60,7 @@ describe('validateSettings', () => {
     const res = validateAppServerSettings({
       codexPath: '/opt/homebrew/bin/codex',
       personality: 'pragmatic',
-      minCodexVersion: '0.105.0',
+      minCodexVersion: '0.130.0',
       sandboxPolicy: 'workspace-write',
     });
     expect(res.valid).toBe(true);

--- a/src/app-server/provider.ts
+++ b/src/app-server/provider.ts
@@ -44,7 +44,7 @@ export interface CodexAppServerProvider extends ProviderV3 {
  * @example
  * ```ts
  * const provider = createCodexAppServer({
- *   defaultSettings: { minCodexVersion: '0.105.0-alpha.0' },
+ *   defaultSettings: { minCodexVersion: '0.130.0' },
  * });
  *
  * try {

--- a/src/app-server/rpc/client.ts
+++ b/src/app-server/rpc/client.ts
@@ -306,7 +306,7 @@ export class AppServerRpcClient extends EventEmitter {
     if (this.serverCapabilities?.modelList === false) {
       throw new UnsupportedFeatureError({
         feature: 'model/list',
-        minCodexVersion: this.settings.minCodexVersion ?? '0.105.0',
+        minCodexVersion: this.settings.minCodexVersion ?? '0.130.0',
         serverVersion: this.serverVersion,
       });
     }
@@ -320,7 +320,7 @@ export class AppServerRpcClient extends EventEmitter {
       if (error instanceof JsonRpcRequestError && error.code === -32601) {
         throw new UnsupportedFeatureError({
           feature: 'model/list',
-          minCodexVersion: this.settings.minCodexVersion ?? '0.105.0',
+          minCodexVersion: this.settings.minCodexVersion ?? '0.130.0',
           serverVersion: this.serverVersion,
         });
       }
@@ -511,7 +511,7 @@ export class AppServerRpcClient extends EventEmitter {
       const message = String((error as Error)?.message ?? error);
       if (message.includes('ENOENT') || message.includes('unknown subcommand')) {
         throw new Error(
-          "codex app-server requires codex CLI >= 0.105.0. Run 'codex --version' to check.",
+          "codex app-server requires codex CLI >= 0.130.0. Run 'codex --version' to check.",
         );
       }
 
@@ -537,7 +537,7 @@ export class AppServerRpcClient extends EventEmitter {
     }
 
     this.serverVersion = detected;
-    const minVersion = this.settings.minCodexVersion ?? '0.105.0';
+    const minVersion = this.settings.minCodexVersion ?? '0.130.0';
     const compared = compareSemver(detected, minVersion);
     if (compared === undefined) {
       this.logger.warn(

--- a/src/exec-language-model.ts
+++ b/src/exec-language-model.ts
@@ -42,6 +42,7 @@ import {
   isPlainObject,
   mapCodexCliFinishReason,
   mapUnsupportedSettingsWarnings,
+  mcpHttpHeadersWithBearerToken,
   mergeMcpServers,
   safeStringify,
   sanitizeJsonSchema,
@@ -402,12 +403,11 @@ export class ExecLanguageModel implements LanguageModelV3 {
         if (server.cwd) this.addConfigOverride(args, `${prefix}.cwd`, server.cwd);
       } else {
         this.addConfigOverride(args, `${prefix}.url`, server.url);
-        if (server.bearerToken !== undefined)
-          this.addConfigOverride(args, `${prefix}.bearer_token`, server.bearerToken);
         if (server.bearerTokenEnvVar)
           this.addConfigOverride(args, `${prefix}.bearer_token_env_var`, server.bearerTokenEnvVar);
-        if (server.httpHeaders !== undefined)
-          this.addConfigOverride(args, `${prefix}.http_headers`, server.httpHeaders);
+        const httpHeaders = mcpHttpHeadersWithBearerToken(server);
+        if (httpHeaders !== undefined)
+          this.addConfigOverride(args, `${prefix}.http_headers`, httpHeaders);
         if (server.envHttpHeaders !== undefined)
           this.addConfigOverride(args, `${prefix}.env_http_headers`, server.envHttpHeaders);
       }

--- a/src/shared-utils.ts
+++ b/src/shared-utils.ts
@@ -122,6 +122,24 @@ export function mergeStringRecord(
   return undefined;
 }
 
+export function mcpHttpHeadersWithBearerToken(
+  server: McpServerHttp,
+): Record<string, string> | undefined {
+  const headers = server.httpHeaders ? { ...server.httpHeaders } : undefined;
+  if (server.bearerToken === undefined) {
+    return headers;
+  }
+
+  const hasAuthorizationHeader = Object.keys(headers ?? {}).some(
+    (key) => key.toLowerCase() === 'authorization',
+  );
+
+  return {
+    ...(headers ?? {}),
+    ...(hasAuthorizationHeader ? {} : { Authorization: `Bearer ${server.bearerToken}` }),
+  };
+}
+
 export function mergeSingleMcpServer(
   existing: McpServerConfig | undefined,
   incoming: McpServerConfig,
@@ -277,13 +295,11 @@ export function mcpServersToConfigOverrides(
       if (server.cwd) setOverride(`${prefix}.cwd`, server.cwd);
     } else {
       setOverride(`${prefix}.url`, server.url);
-      if (server.bearerToken !== undefined)
-        setOverride(`${prefix}.bearer_token`, server.bearerToken);
       if (server.bearerTokenEnvVar !== undefined) {
         setOverride(`${prefix}.bearer_token_env_var`, server.bearerTokenEnvVar);
       }
-      if (server.httpHeaders !== undefined)
-        setOverride(`${prefix}.http_headers`, server.httpHeaders);
+      const httpHeaders = mcpHttpHeadersWithBearerToken(server);
+      if (httpHeaders !== undefined) setOverride(`${prefix}.http_headers`, httpHeaders);
       if (server.envHttpHeaders !== undefined) {
         setOverride(`${prefix}.env_http_headers`, server.envHttpHeaders);
       }

--- a/src/shared-utils.ts
+++ b/src/shared-utils.ts
@@ -122,6 +122,15 @@ export function mergeStringRecord(
   return undefined;
 }
 
+function omitAuthorizationHeader(
+  headers?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (headers === undefined) return undefined;
+  return Object.fromEntries(
+    Object.entries(headers).filter(([key]) => key.toLowerCase() !== 'authorization'),
+  );
+}
+
 export function mcpHttpHeadersWithBearerToken(
   server: McpServerHttp,
 ): Record<string, string> | undefined {
@@ -172,13 +181,16 @@ export function mergeSingleMcpServer(
   const bearerTokenEnvVar = hasIncomingAuth
     ? incoming.bearerTokenEnvVar
     : baseHttp.bearerTokenEnvVar;
+  const baseHttpHeaders = hasIncomingAuth
+    ? omitAuthorizationHeader(baseHttp.httpHeaders)
+    : baseHttp.httpHeaders;
 
   const result: McpServerConfig = {
     transport: 'http',
     url: incoming.url,
     bearerToken,
     bearerTokenEnvVar,
-    httpHeaders: mergeStringRecord(baseHttp.httpHeaders, incoming.httpHeaders),
+    httpHeaders: mergeStringRecord(baseHttpHeaders, incoming.httpHeaders),
     envHttpHeaders: mergeStringRecord(baseHttp.envHttpHeaders, incoming.envHttpHeaders),
     enabled: incoming.enabled ?? existing.enabled,
     startupTimeoutSec: incoming.startupTimeoutSec ?? existing.startupTimeoutSec,

--- a/src/types-shared.ts
+++ b/src/types-shared.ts
@@ -12,6 +12,7 @@ export interface Logger {
  * Known Codex-capable model IDs with string fallback for forward compatibility.
  */
 export type CodexModelId =
+  | 'gpt-5.5'
   | 'gpt-5.3-codex'
   | 'gpt-5.2-codex'
   | 'gpt-5.2-codex-max'


### PR DESCRIPTION
## Summary

Pins the optional `@openai/codex` dependency to `^0.130.0`, the current validated non-alpha Codex CLI release line, instead of continuing to cap installs at the older `0.105.x` line.

This also updates provider defaults, docs, tests, and examples so the maintained baseline is explicit and consistent across both `codexExec` and `codexAppServer`.

Closes #27.

## What Changed

- Updated the optional `@openai/codex` dependency to `^0.130.0`.
- Raised app-server minimum/default Codex CLI references to `0.130.0`.
- Added compatibility handling for newer Codex CLI MCP HTTP auth config behavior.
- Refreshed examples and README snippets to use `gpt-5.5`.
- Tightened app-server example expectations for long prompts, multiple shell-tool calls, logging, raw chunks, and related streaming behavior.
- Added/updated tests around version checks, config handling, and exec/app-server behavior.
- Refreshed `package-lock.json`.

## Notes

Issue #27 originally proposed widening the supported range back to `0.105.0`, but local compatibility testing could not safely validate `0.105.0` because macOS blocked that older `codex` binary as malware. Since `0.130.0` is the latest non-alpha release we validated locally, this PR pins support to the safer `0.130.x` release line instead of advertising an older unverified range.

## Validation

- `npm run validate`
- `npm run validate:docs`
- `npm run validate:examples:app-server`
