### PR TITLE
Fix provider-executed tool stream metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-05-25
+
+### Fixed
+
+- Mark provider-executed Codex tools as dynamic in AI SDK streams so app-server tools such as `exec`, `patch`, and `web_search`, plus exec-mode tool events, are not rejected as unavailable caller tools when consumed through `toUIMessageStream()`.
+
 ## [1.2.0] - 2026-05-15
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-codex-cli",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "AI SDK v6 provider for OpenAI Codex CLI (use ChatGPT Plus/Pro subscription)",
   "keywords": [
     "ai-sdk",

--- a/src/__tests__/app-server-language-model.test.ts
+++ b/src/__tests__/app-server-language-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { streamText } from 'ai';
 import { EventEmitter } from 'node:events';
 import { existsSync } from 'node:fs';
 import type { TurnStartParams } from '../app-server/protocol/types.js';
@@ -745,6 +746,75 @@ describe('AppServerLanguageModel', () => {
     expect(finish?.providerMetadata?.['codex-app-server']?.toolExecutionStats?.totalCalls).toBe(1);
     expect(finish?.providerMetadata?.['codex-app-server']?.toolExecutionStats?.byType?.exec).toBe(
       1,
+    );
+  });
+
+  it('marks provider-executed app-server tools dynamic for AI SDK UI streams', async () => {
+    const client = new FakeClient();
+    client.turnStartImpl = async (params) => {
+      setTimeout(() => {
+        client.emit('notification', 'item/started', {
+          threadId: params.threadId,
+          turnId: 'turn_web_ui_1',
+          item: {
+            type: 'webSearch',
+            id: 'ws_ui_1',
+            query: 'latest United States news',
+            action: { type: 'search', queries: ['latest United States news'] },
+          },
+        });
+        client.emit('notification', 'item/completed', {
+          threadId: params.threadId,
+          turnId: 'turn_web_ui_1',
+          item: {
+            type: 'webSearch',
+            id: 'ws_ui_1',
+            query: 'latest United States news',
+            action: { type: 'search', queries: ['latest United States news'] },
+          },
+        });
+        client.emit('notification', 'turn/completed', {
+          threadId: params.threadId,
+          turn: { id: 'turn_web_ui_1', items: [], status: 'completed', error: null },
+        });
+      }, 5);
+      return { turn: { id: 'turn_web_ui_1' } };
+    };
+
+    const model = new AppServerLanguageModel({ id: 'gpt-5.3-codex', client: client as never });
+    const result = streamText({
+      model: model as never,
+      prompt: 'Use web search for current news.',
+    });
+
+    const parts: unknown[] = [];
+    for await (const part of result.toUIMessageStream()) {
+      parts.push(part);
+    }
+
+    expect(JSON.stringify(parts)).not.toContain('Model tried to call unavailable tool');
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-input-start',
+        toolName: 'web_search',
+        providerExecuted: true,
+        dynamic: true,
+      }),
+    );
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-input-available',
+        toolName: 'web_search',
+        providerExecuted: true,
+        dynamic: true,
+      }),
+    );
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-output-available',
+        providerExecuted: true,
+        dynamic: true,
+      }),
     );
   });
 

--- a/src/__tests__/app-server-stream-emitter.test.ts
+++ b/src/__tests__/app-server-stream-emitter.test.ts
@@ -163,7 +163,7 @@ describe('AppServerStreamEmitter', () => {
     });
 
     emitter.emitApprovalRequest('approval_1');
-    emitter.emitToolOutputDelta('tool_1', 'exec', 'chunk');
+    emitter.emitToolOutputDelta('tool_1', 'exec', 'chunk', true);
 
     expect(parts).toContainEqual({
       type: 'tool-approval-request',
@@ -175,6 +175,7 @@ describe('AppServerStreamEmitter', () => {
         if (part.type !== 'tool-result') return false;
         return (
           part.toolCallId === 'tool_1' &&
+          part.dynamic === true &&
           (part.result as { type?: string; delta?: string }).type === 'output-delta'
         );
       }),

--- a/src/__tests__/exec-language-model.test.ts
+++ b/src/__tests__/exec-language-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { streamText } from 'ai';
 import { ExecLanguageModel } from '../exec-language-model.js';
 import { PassThrough } from 'node:stream';
 import { EventEmitter } from 'node:events';
@@ -144,10 +145,12 @@ describe('ExecLanguageModel', () => {
       type: 'tool-call',
       toolName: 'exec',
       providerExecuted: true,
+      dynamic: true,
     });
     expect(res.content[1]).toMatchObject({
       type: 'tool-result',
       toolName: 'exec',
+      dynamic: true,
       result: {
         command: 'ls -la',
         aggregatedOutput: 'README.md\n',
@@ -243,10 +246,12 @@ describe('ExecLanguageModel', () => {
     const toolCall = received.find((p) => p.type === 'tool-call');
     expect(toolCall?.toolName).toBe('exec');
     expect(toolCall?.providerExecuted).toBe(true);
+    expect(toolCall?.dynamic).toBe(true);
     expect(toolCall?.input).toContain('ls -la');
 
     const toolResult = received.find((p) => p.type === 'tool-result');
     expect(toolResult?.toolCallId).toBe(toolCall?.toolCallId);
+    expect(toolResult?.dynamic).toBe(true);
     expect(toolResult?.result).toMatchObject({
       command: 'ls -la',
       aggregatedOutput: 'README.md\n',
@@ -261,6 +266,78 @@ describe('ExecLanguageModel', () => {
     });
     expect(finish?.usage.raw).toBeDefined();
     expect(finish?.finishReason).toEqual({ unified: 'stop', raw: undefined });
+  });
+
+  it('marks provider-executed exec tools dynamic for AI SDK UI streams', async () => {
+    const lines = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-tools-ui' }),
+      JSON.stringify({
+        type: 'item.started',
+        item: {
+          id: 'item_ui_0',
+          item_type: 'command_execution',
+          command: 'ls -la',
+          aggregated_output: '',
+          exit_code: null,
+          status: 'in_progress',
+        },
+      }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'item_ui_0',
+          item_type: 'command_execution',
+          command: 'ls -la',
+          aggregated_output: 'README.md\n',
+          exit_code: 0,
+          status: 'completed',
+        },
+      }),
+      JSON.stringify({
+        type: 'turn.completed',
+        usage: { input_tokens: 4, output_tokens: 2, cached_input_tokens: 1 },
+      }),
+    ];
+    (childProc as any).__setSpawnMock(makeMockSpawn(lines, 0));
+
+    const model = new ExecLanguageModel({
+      id: 'gpt-5',
+      settings: { allowNpx: true, color: 'never' },
+    });
+    const result = streamText({
+      model: model as never,
+      prompt: 'List files',
+    });
+
+    const parts: unknown[] = [];
+    for await (const part of result.toUIMessageStream()) {
+      parts.push(part);
+    }
+
+    expect(JSON.stringify(parts)).not.toContain('Model tried to call unavailable tool');
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-input-start',
+        toolName: 'exec',
+        providerExecuted: true,
+        dynamic: true,
+      }),
+    );
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-input-available',
+        toolName: 'exec',
+        providerExecuted: true,
+        dynamic: true,
+      }),
+    );
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-output-available',
+        providerExecuted: true,
+        dynamic: true,
+      }),
+    );
   });
 
   it('includes approval/sandbox flags and output-last-message; uses npx with allowNpx', async () => {

--- a/src/app-server/stream/emitter.ts
+++ b/src/app-server/stream/emitter.ts
@@ -145,7 +145,12 @@ export class AppServerStreamEmitter {
     });
   }
 
-  emitToolOutputDelta(toolCallId: string, toolName: string, delta: string): void {
+  emitToolOutputDelta(
+    toolCallId: string,
+    toolName: string,
+    delta: string,
+    dynamic?: boolean,
+  ): void {
     this.safeEnqueue({
       type: 'tool-result',
       toolCallId,
@@ -155,6 +160,7 @@ export class AppServerStreamEmitter {
         type: 'output-delta',
         delta,
       } as NonNullable<JSONValue>,
+      ...(dynamic ? { dynamic: true } : {}),
     });
   }
 

--- a/src/app-server/stream/router-notification-handlers.ts
+++ b/src/app-server/stream/router-notification-handlers.ts
@@ -13,11 +13,11 @@ function mapTool(item: ThreadItem): { toolName: string; dynamic?: boolean } | un
   const type = normalizeItemType(item.type);
 
   if (type === 'commandexecution') {
-    return { toolName: 'exec' };
+    return { toolName: 'exec', dynamic: true };
   }
 
   if (type === 'filechange') {
-    return { toolName: 'patch' };
+    return { toolName: 'patch', dynamic: true };
   }
 
   if (type === 'mcptoolcall') {
@@ -36,7 +36,7 @@ function mapTool(item: ThreadItem): { toolName: string; dynamic?: boolean } | un
   }
 
   if (type === 'websearch') {
-    return { toolName: 'web_search' };
+    return { toolName: 'web_search', dynamic: true };
   }
 
   return undefined;
@@ -139,6 +139,7 @@ export function createNotificationHandlers(
         itemId,
         tracked?.toolName ?? defaultToolName,
         params.delta,
+        tracked?.dynamic ?? true,
       );
     };
 

--- a/src/exec-language-model.ts
+++ b/src/exec-language-model.ts
@@ -616,7 +616,13 @@ export class ExecLanguageModel implements LanguageModelV3 {
     inputPayload: unknown,
   ): void {
     const inputString = safeStringify(inputPayload);
-    controller.enqueue({ type: 'tool-input-start', id: toolCallId, toolName });
+    controller.enqueue({
+      type: 'tool-input-start',
+      id: toolCallId,
+      toolName,
+      providerExecuted: true,
+      dynamic: true,
+    });
     if (inputString) {
       controller.enqueue({ type: 'tool-input-delta', id: toolCallId, delta: inputString });
     }
@@ -627,6 +633,7 @@ export class ExecLanguageModel implements LanguageModelV3 {
       toolName,
       input: inputString,
       providerExecuted: true,
+      dynamic: true,
     });
   }
 
@@ -665,6 +672,7 @@ export class ExecLanguageModel implements LanguageModelV3 {
       toolCallId,
       toolName,
       result: (resultPayload ?? {}) as NonNullable<import('@ai-sdk/provider').JSONValue>,
+      dynamic: true,
       ...(isError ? { isError: true } : {}),
       ...(Object.keys(providerMetadataEntries).length
         ? { providerMetadata: { 'codex-cli': providerMetadataEntries } }


### PR DESCRIPTION
Fixes #30

## Summary
- Mark Codex provider-executed tool events as dynamic in app-server and exec streams
- Preserve providerExecuted + dynamic metadata for app-server web_search/exec/patch and exec-mode tool events
- Add AI SDK toUIMessageStream regression coverage and bump package version to 1.2.1

## Validation
- npm run validate