### PR TITLE
fix: handle mcpServer/elicitation/request so MCP tool calls work on Codex >= 0.139

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Handle the `mcpServer/elicitation/request` server request introduced by Codex CLI >= 0.139 so MCP tool calls are no longer always rejected (#33). MCP tool call approval elicitations (`_meta.codex_approval_kind === 'mcp_tool_call'`) are accepted when `autoApprove` is `true` and declined otherwise; all other elicitations (for example plugin install suggestions and URL elicitations) are declined instead of failing with JSON-RPC `-32601`.
+
+### Added
+
+- New typed `onMcpElicitation` handler on `serverRequests` for custom MCP elicitation handling; `onUnhandled` is still consulted as a fallback for this method, preserving existing workarounds.
+
 ## [1.2.1] - 2026-05-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ See [docs/ai-sdk-v5/configuration.md](docs/ai-sdk-v5/configuration.md) for the f
 - `minCodexVersion`: minimum supported app-server version (semver)
 - `includeRawChunks`: emit raw JSON-RPC notifications as `raw` stream parts by default
 - `serverRequests`: typed handlers for server-initiated JSON-RPC requests
-- `autoApprove`: default approval response when no custom handler is provided
+- `autoApprove`: default approval response when no custom handler is provided (covers command execution, file changes, skills, and MCP tool call approvals via `mcpServer/elicitation/request` on Codex >= 0.139)
 - `persistExtendedHistory`: request extended thread history persistence
 - `threadMode`: `stateless` (default) or `persistent` automatic thread reuse
 - `resume`: shorthand to resume an existing thread id

--- a/src/__tests__/app-server-rpc-client.test.ts
+++ b/src/__tests__/app-server-rpc-client.test.ts
@@ -320,6 +320,135 @@ describe('AppServerRpcClient', () => {
     await client.close();
   });
 
+  it('accepts MCP tool call elicitations when autoApprove is true', async () => {
+    const { child, writes } = createMockProcess();
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient({ settings: { autoApprove: true } });
+    await client.ensureReady();
+
+    await callServerRequest(client, 31, 'mcpServer/elicitation/request', {
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      serverName: 'everything',
+      mode: 'form',
+      _meta: { codex_approval_kind: 'mcp_tool_call', persist: ['session', 'always'] },
+      message: 'Allow the everything MCP server to run tool "echo"?',
+      requestedSchema: { type: 'object', properties: {} },
+    });
+
+    expect(writes).toContainEqual({ id: 31, result: { action: 'accept', content: {} } });
+    await client.close();
+  });
+
+  it('declines MCP tool call elicitations when autoApprove is false', async () => {
+    const { child, writes } = createMockProcess();
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient({ settings: { autoApprove: false } });
+    await client.ensureReady();
+
+    await callServerRequest(client, 32, 'mcpServer/elicitation/request', {
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      serverName: 'everything',
+      mode: 'form',
+      _meta: { codex_approval_kind: 'mcp_tool_call' },
+      message: 'Allow the everything MCP server to run tool "echo"?',
+      requestedSchema: { type: 'object', properties: {} },
+    });
+
+    expect(writes).toContainEqual({ id: 32, result: { action: 'decline', content: null } });
+    await client.close();
+  });
+
+  it('declines non tool-call elicitations even when autoApprove is true', async () => {
+    const { child, writes } = createMockProcess();
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient({ settings: { autoApprove: true } });
+    await client.ensureReady();
+
+    await callServerRequest(client, 33, 'mcpServer/elicitation/request', {
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      serverName: 'codex_apps',
+      mode: 'form',
+      _meta: { codex_approval_kind: 'tool_suggestion', suggest_type: 'install' },
+      message: 'Install the Slack plugin?',
+      requestedSchema: { type: 'object', properties: {} },
+    });
+    await callServerRequest(client, 34, 'mcpServer/elicitation/request', {
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      serverName: 'everything',
+      mode: 'url',
+      message: 'Open this URL to continue',
+      url: 'https://example.com/auth',
+      elicitationId: 'elic_1',
+    });
+
+    expect(writes).toContainEqual({ id: 33, result: { action: 'decline', content: null } });
+    expect(writes).toContainEqual({ id: 34, result: { action: 'decline', content: null } });
+    await client.close();
+  });
+
+  it('prefers onMcpElicitation handler over built-in elicitation defaults', async () => {
+    const { child, writes } = createMockProcess();
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient({
+      settings: {
+        autoApprove: false,
+        serverRequests: {
+          onMcpElicitation: async () => ({ action: 'accept' as const, content: {} }),
+        },
+      },
+    });
+    await client.ensureReady();
+
+    await callServerRequest(client, 35, 'mcpServer/elicitation/request', {
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      serverName: 'everything',
+      mode: 'form',
+      _meta: { codex_approval_kind: 'mcp_tool_call' },
+      message: 'Allow the everything MCP server to run tool "echo"?',
+      requestedSchema: { type: 'object', properties: {} },
+    });
+
+    expect(writes).toContainEqual({ id: 35, result: { action: 'accept', content: {} } });
+    await client.close();
+  });
+
+  it('falls back to onUnhandled for elicitations when onMcpElicitation is absent', async () => {
+    const { child, writes } = createMockProcess();
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient({
+      settings: {
+        autoApprove: false,
+        serverRequests: {
+          onUnhandled: async () => ({ action: 'accept', content: {} }),
+        },
+      },
+    });
+    await client.ensureReady();
+
+    await callServerRequest(client, 36, 'mcpServer/elicitation/request', {
+      threadId: 'thr_1',
+      turnId: 'turn_1',
+      serverName: 'everything',
+      mode: 'form',
+      _meta: { codex_approval_kind: 'mcp_tool_call' },
+      message: 'Allow the everything MCP server to run tool "echo"?',
+      requestedSchema: { type: 'object', properties: {} },
+    });
+
+    expect(writes).toContainEqual({ id: 36, result: { action: 'accept', content: {} } });
+    await client.close();
+  });
+
   it('honors per-thread autoApprove override over client-level setting', async () => {
     const { child, writes } = createMockProcess();
     setSpawnMock(() => child);

--- a/src/__tests__/fixtures/app-server-protocol/server-requests/mcp-elicitation.json
+++ b/src/__tests__/fixtures/app-server-protocol/server-requests/mcp-elicitation.json
@@ -1,0 +1,31 @@
+{
+  "id": 0,
+  "method": "mcpServer/elicitation/request",
+  "params": {
+    "threadId": "019eb8d5-83a0-7a80-b030-5522bff32ebb",
+    "turnId": "019eb8d5-83a7-7321-b059-39b655e1e130",
+    "serverName": "everything",
+    "mode": "form",
+    "_meta": {
+      "codex_approval_kind": "mcp_tool_call",
+      "persist": ["session", "always"],
+      "tool_title": "Echo Tool",
+      "tool_description": "Echoes back the input string",
+      "tool_params": {
+        "message": "ping"
+      },
+      "tool_params_display": [
+        {
+          "name": "message",
+          "value": "ping",
+          "display_name": "message"
+        }
+      ]
+    },
+    "message": "Allow the everything MCP server to run tool \"echo\"?",
+    "requestedSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  }
+}

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -88,6 +88,16 @@ describe('validateSettings', () => {
     expect(res.errors).toHaveLength(0);
   });
 
+  it('accepts onMcpElicitation in app-server serverRequests', () => {
+    const res = validateAppServerSettings({
+      serverRequests: {
+        onMcpElicitation: async () => ({ action: 'accept', content: {} }),
+      },
+    });
+    expect(res.valid).toBe(true);
+    expect(res.errors).toHaveLength(0);
+  });
+
   it('rejects invalid app-server serverRequests values', () => {
     const res = validateAppServerSettings({
       serverRequests: {

--- a/src/app-server/protocol/types.ts
+++ b/src/app-server/protocol/types.ts
@@ -444,6 +444,32 @@ export interface ToolRequestUserInputResponse {
   answers: Record<string, unknown>;
 }
 
+export type McpServerElicitationAction = 'accept' | 'decline' | 'cancel';
+
+export interface McpServerElicitationRequestParams {
+  threadId: string;
+  /** Nullable: the elicitation may arrive outside of an active turn. */
+  turnId?: string | null;
+  serverName: string;
+  /** 'form' requests carry message/requestedSchema; 'url' requests carry url/elicitationId. */
+  mode?: string;
+  message?: string;
+  requestedSchema?: unknown;
+  url?: string;
+  elicitationId?: string;
+  /**
+   * For MCP tool approval elicitations, Codex sets
+   * `codex_approval_kind: 'mcp_tool_call'` and may include `persist` hints.
+   */
+  _meta?: Record<string, unknown> | null;
+}
+
+export interface McpServerElicitationRequestResponse {
+  action: McpServerElicitationAction;
+  /** Structured user input for accepted elicitations; null for decline/cancel. */
+  content?: Record<string, unknown> | null;
+}
+
 export interface DynamicToolCallParams {
   threadId: string;
   turnId: string;

--- a/src/app-server/protocol/validators.ts
+++ b/src/app-server/protocol/validators.ts
@@ -431,6 +431,20 @@ const skillRequestApprovalParamsSchema = z
   })
   .passthrough();
 
+const mcpServerElicitationRequestParamsSchema = z
+  .object({
+    threadId: z.string(),
+    turnId: z.string().nullable().optional(),
+    serverName: z.string(),
+    mode: z.string().optional(),
+    message: z.string().optional(),
+    requestedSchema: z.unknown().optional(),
+    url: z.string().optional(),
+    elicitationId: z.string().optional(),
+    _meta: z.record(z.string(), z.unknown()).nullable().optional(),
+  })
+  .passthrough();
+
 const dynamicToolCallParamsSchema = z
   .object({
     threadId: z.string(),
@@ -452,6 +466,7 @@ export const serverRequestParamSchemas = {
   'item/commandExecution/requestApproval': commandExecutionRequestApprovalParamsSchema,
   'item/fileChange/requestApproval': fileChangeRequestApprovalParamsSchema,
   'item/tool/requestUserInput': toolRequestUserInputParamsSchema,
+  'mcpServer/elicitation/request': mcpServerElicitationRequestParamsSchema,
   'skill/requestApproval': skillRequestApprovalParamsSchema,
   'item/tool/call': dynamicToolCallParamsSchema,
   'account/chatgptAuthTokens/refresh': chatgptAuthTokensRefreshParamsSchema,
@@ -484,6 +499,13 @@ export const serverRequestSchema = z.discriminatedUnion('method', [
       id: jsonRpcIdSchema,
       method: z.literal('item/tool/requestUserInput'),
       params: toolRequestUserInputParamsSchema,
+    })
+    .passthrough(),
+  z
+    .object({
+      id: jsonRpcIdSchema,
+      method: z.literal('mcpServer/elicitation/request'),
+      params: mcpServerElicitationRequestParamsSchema,
     })
     .passthrough(),
   z

--- a/src/app-server/rpc/client.ts
+++ b/src/app-server/rpc/client.ts
@@ -11,6 +11,7 @@ import type {
   AppServerCommandExecutionApprovalRequest,
   AppServerDynamicToolCallRequest,
   AppServerFileChangeApprovalRequest,
+  AppServerMcpElicitationRequest,
   AppServerSkillApprovalRequest,
   AppServerToolRequestUserInputRequest,
   AppServerUnhandledRequest,
@@ -854,6 +855,33 @@ export class AppServerRpcClient extends EventEmitter {
           return;
         }
         await sendResult({ decision: autoApprove ? 'approve' : 'decline' });
+        return;
+      }
+      case 'mcpServer/elicitation/request': {
+        const handled = await runHandler(() =>
+          handlers.onMcpElicitation?.(normalized as unknown as AppServerMcpElicitationRequest),
+        );
+        if (handled !== undefined) {
+          await sendResult(handled);
+          return;
+        }
+        const fallback = await runHandler(() =>
+          handlers.onUnhandled?.(normalized as unknown as AppServerUnhandledRequest),
+        );
+        if (fallback !== undefined) {
+          await sendResult(fallback);
+          return;
+        }
+        const meta = normalized.params._meta as
+          | { codex_approval_kind?: unknown }
+          | null
+          | undefined;
+        const isToolCallApproval = meta?.codex_approval_kind === 'mcp_tool_call';
+        if (isToolCallApproval && autoApprove) {
+          await sendResult({ action: 'accept', content: {} });
+        } else {
+          await sendResult({ action: 'decline', content: null });
+        }
         return;
       }
       case 'item/tool/requestUserInput': {

--- a/src/app-server/types.ts
+++ b/src/app-server/types.ts
@@ -8,6 +8,8 @@ import type {
   DynamicToolCallResponse,
   FileChangeRequestApprovalParams,
   FileChangeRequestApprovalResponse,
+  McpServerElicitationRequestParams,
+  McpServerElicitationRequestResponse,
   SkillRequestApprovalParams,
   SkillRequestApprovalResponse,
   ToolRequestUserInputParams,
@@ -104,6 +106,12 @@ export interface AppServerSkillApprovalRequest {
   params: SkillRequestApprovalParams;
 }
 
+export interface AppServerMcpElicitationRequest {
+  id: JsonRpcId;
+  method: 'mcpServer/elicitation/request';
+  params: McpServerElicitationRequestParams;
+}
+
 export interface AppServerToolRequestUserInputRequest {
   id: JsonRpcId;
   method: 'item/tool/requestUserInput';
@@ -126,6 +134,7 @@ export type AppServerTypedRequest =
   | AppServerCommandExecutionApprovalRequest
   | AppServerFileChangeApprovalRequest
   | AppServerSkillApprovalRequest
+  | AppServerMcpElicitationRequest
   | AppServerToolRequestUserInputRequest
   | AppServerDynamicToolCallRequest
   | AppServerAuthRefreshRequest;
@@ -155,6 +164,15 @@ export interface CodexAppServerRequestHandlers {
   onSkillApproval?: (
     request: AppServerSkillApprovalRequest,
   ) => Promise<SkillRequestApprovalResponse | undefined>;
+  /**
+   * Handles `mcpServer/elicitation/request` (Codex >= 0.139), which includes
+   * MCP tool call approvals (`params._meta.codex_approval_kind === 'mcp_tool_call'`).
+   * Built-in default: accept tool call approvals when `autoApprove` is true,
+   * decline all other elicitations.
+   */
+  onMcpElicitation?: (
+    request: AppServerMcpElicitationRequest,
+  ) => Promise<McpServerElicitationRequestResponse | undefined>;
   onToolRequestUserInput?: (
     request: AppServerToolRequestUserInputRequest,
   ) => Promise<ToolRequestUserInputResponse | undefined>;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -158,6 +158,12 @@ const serverRequestsSchema = z
         message: 'onSkillApproval must be a function',
       })
       .optional(),
+    onMcpElicitation: z
+      .any()
+      .refine((val) => val === undefined || typeof val === 'function', {
+        message: 'onMcpElicitation must be a function',
+      })
+      .optional(),
     onToolRequestUserInput: z
       .any()
       .refine((val) => val === undefined || typeof val === 'function', {


### PR DESCRIPTION
Fixes #33

## Problem

Codex CLI >= 0.139 wraps MCP tool call approval in an MCP elicitation sent to the app-server client as a server-initiated JSON-RPC request: `mcpServer/elicitation/request`. The RPC client's request dispatch had no case for this method, so it fell through to the default branch and answered with `-32601 Method not supported`, which Codex treats as a rejection. Result: every MCP tool call failed with `user rejected MCP tool call`, regardless of `autoApprove` or `approvalPolicy` (those only applied to the typed approval handlers).

Reproduced end-to-end with Codex CLI 0.139.0 under a default config using the exact repro from #33; the captured elicitation payload matches the reporter's byte-for-byte in structure.

## Fix

- Add a typed `onMcpElicitation` handler to `CodexAppServerRequestHandlers`. `onUnhandled` is still consulted as a fallback for this method, so the community workaround from #33 keeps working unchanged.
- Built-in default behavior when no handler responds:
  - Elicitations with `_meta.codex_approval_kind === 'mcp_tool_call'` are **accepted** when `autoApprove: true` and **declined** otherwise — consistent with the existing command-execution/file-change approval defaults.
  - All other elicitations (e.g. `tool_suggestion` plugin-install prompts, `mode: "url"` requests) are **declined** gracefully instead of erroring with `-32601`, since there is no interactive user to consult.
- Add `McpServerElicitationRequestParams`/`McpServerElicitationRequestResponse` protocol types, zod validators wired into `serverRequestSchema`, and a protocol fixture captured from a real Codex 0.139.0 session.

### Why not auto-accept for declared servers?

Issue #33 suggested auto-accepting whenever `serverName` matches a server declared in `mcpServers`. The elicitation channel carries more than tool-call approvals — including plugin-install suggestions and URL elicitations — so unconditional acceptance keyed on server name alone would be unsafe. Acceptance is gated strictly on the `mcp_tool_call` approval kind plus `autoApprove`. Users who want broader acceptance can implement it in one line via `onMcpElicitation`.

## Validation

- `npm run lint`, `npm run typecheck`: clean
- `npx vitest run`: 346 passed, 1 skipped (includes 5 new unit tests covering accept/decline/non-tool-call/handler-precedence/onUnhandled-fallback paths)
- Live verification against Codex CLI 0.139.0 with an isolated default `CODEX_HOME`:
  - `autoApprove: true` → `Echo: ping` (tool call executes)
  - `autoApprove: false` → graceful `user rejected MCP tool call` (no protocol error)