### PR TITLE
feat!: AI SDK v7 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Node.js >= 22 required**: the supported `engines` floor moves from Node 18 to Node 22
 - **ESM-only package**: the CJS build, the `require` export condition, and the `main`/`module` fields are removed; consume via `import` (or dynamic `import()` from CommonJS)
 - **Legacy model properties removed**: v6-era model properties are gone in favor of the v4 model surface; models now expose the v4 `supportedUrls` map (currently `{}`)
+- **`zod` peer dependency is Zod 4 only**: `^4.1.8` (Zod 3 is not supported). Importing under Zod 3 throws because `.refine().passthrough()` is unavailable on Zod 3's `ZodEffects`. 1.x allowed `zod@^3.0.0 || ^4.0.0`.
 
 ### Added
 
@@ -30,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `@ai-sdk/provider`: ^4.0.0
   - `@ai-sdk/provider-utils`: ^5.0.0
   - `ai` (dev): ^7.0.0
-- `zod` peer dependency narrowed to `^3.25.76 || ^4.1.8`
+- `zod` peer dependency narrowed to `^4.1.8` (Zod 4 only; see Breaking Changes)
 - Model discovery guidance: documentation no longer maintains a static model catalog; use `listModels()` / `provider.listModels()` — available slugs follow your installed Codex CLI
 - Optional `@openai/codex` dependency: `^0.130.0` → `^0.142.5`; app-server protocol types synced with and release-tested against Codex CLI 0.142.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-07-06
+
+### Breaking Changes
+
+- **AI SDK v7 migration** - This release requires AI SDK v7 and is incompatible with AI SDK v6
+- **Provider interface**: `LanguageModelV3` → `LanguageModelV4`, `ProviderV3` → `ProviderV4` (native implementation, no compatibility layer)
+- **Specification version**: `specificationVersion` changed from `'v3'` to `'v4'` on both providers and models
+- **Node.js >= 22 required**: the supported `engines` floor moves from Node 18 to Node 22
+- **ESM-only package**: the CJS build, the `require` export condition, and the `main`/`module` fields are removed; consume via `import` (or dynamic `import()` from CommonJS)
+- **Legacy model properties removed**: v6-era model properties are gone in favor of the v4 model surface; models now expose the v4 `supportedUrls` map (currently `{}`)
+
+### Added
+
+- **Top-level `reasoning` call option**: AI SDK v7's `reasoning` option (`'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'`) maps to Codex reasoning effort in both provider modes. Provider-specific options keep precedence (`providerOptions['codex-cli'].reasoningEffort` / `providerOptions['codex-app-server'].effort` win when set), `'provider-default'` leaves configured defaults untouched, and unsupported values emit an `unsupported` warning instead of failing
+- **v4 content handling**:
+  - v4 tagged file data (`{ type: 'data' | 'url' | 'reference' | 'text' }`) is accepted for file/image message parts, with legacy untagged data shapes still supported for compatibility
+  - canonical v4 tool-result file content is rendered into prompt text across its `data`/`url`/`reference`/`text` variants, with warnings for unrecognized data types
+  - `custom` content parts (in prompts and tool results) and assistant `reasoning-file` parts are skipped with explicit `unsupported` warnings
+
+### Changed
+
+- Dependencies updated for AI SDK v7:
+  - `@ai-sdk/provider`: ^4.0.0
+  - `@ai-sdk/provider-utils`: ^5.0.0
+  - `ai` (dev): ^7.0.0
+- `zod` peer dependency narrowed to `^3.25.76 || ^4.1.8`
+- Model discovery guidance: documentation no longer maintains a static model catalog; use `listModels()` / `provider.listModels()` — available slugs follow your installed Codex CLI
+
+### Migration from AI SDK v6
+
+AI SDK v6 users should stay on the 1.x package line via the `ai-sdk-v6` dist-tag:
+
+```bash
+npm i ai@^6 ai-sdk-provider-codex-cli@ai-sdk-v6
+```
+
+See [docs/ai-sdk-v7/migration-v6-to-v7.md](docs/ai-sdk-v7/migration-v6-to-v7.md) for the full migration guide.
+
+### Version Compatibility
+
+| Package line      | AI SDK | npm tag               | Git branch  | Status                       |
+| ----------------- | ------ | --------------------- | ----------- | ---------------------------- |
+| 2.x               | v7     | `latest`, `ai-sdk-v7` | `main`      | Active development           |
+| 1.x               | v6     | `ai-sdk-v6`           | `ai-sdk-v6` | Maintenance                  |
+| 0.7.x             | v5     | `ai-sdk-v5`           | `ai-sdk-v5` | Maintenance / critical fixes |
+| `0.1.0-ai-sdk-v4` | v4     | `ai-sdk-v4`           | `ai-sdk-v4` | Frozen                       |
+
 ## [1.2.2] - 2026-06-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ai` (dev): ^7.0.0
 - `zod` peer dependency narrowed to `^3.25.76 || ^4.1.8`
 - Model discovery guidance: documentation no longer maintains a static model catalog; use `listModels()` / `provider.listModels()` — available slugs follow your installed Codex CLI
+- Optional `@openai/codex` dependency: `^0.130.0` → `^0.142.5`; app-server protocol types synced with and release-tested against Codex CLI 0.142.5
 
 ### Migration from AI SDK v6
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,10 +1,14 @@
 # Known Limitations
 
-## Native JSON Schema Support (v0.2.0+)
+This document covers the 2.x package line (AI SDK v7) and applies to both provider modes — `codexExec` and `codexAppServer` — except where a mode is called out explicitly. For a condensed overview, see [docs/ai-sdk-v7/limitations.md](docs/ai-sdk-v7/limitations.md).
+
+## Native JSON Schema Support
+
+Structured output (`generateObject`, `streamObject`, and `responseFormat: { type: 'json' }`) is implemented with OpenAI's strict-mode output schemas. The provider sanitizes your JSON schema and passes it to Codex — via `--output-schema` in exec mode and the `outputSchema` turn parameter in app-server mode. Strict mode imposes the constraints below in both modes.
 
 ### Optional Fields Not Supported
 
-**OpenAI's strict mode** (used by `--output-schema`) **does not support optional fields**. All properties in the schema must be in the `required` array.
+**OpenAI's strict mode does not support optional fields.** All properties in the schema must be in the `required` array.
 
 **Impact:**
 
@@ -84,46 +88,54 @@ const schema = z.object({
 
 ### Image Support
 
-The provider supports multimodal (image) inputs, but with some limitations:
+The provider supports multimodal (image) inputs with these characteristics:
 
-**Not supported:**
-
-- HTTP/HTTPS image URLs - Images must be provided as binary data (Buffer, Uint8Array) or base64 strings
-- The AI SDK will pass images as base64 data, which the provider handles correctly
-
-**How it works:**
-
-- Images are written to temporary files
-- Passed to Codex CLI via the `--image` flag
-- Temp files are automatically cleaned up after the request completes
-
-**Supported formats:**
+**Supported input forms:**
 
 - Base64 data URLs (`data:image/png;base64,...`)
 - Raw base64 strings
 - `Buffer` / `Uint8Array` / `ArrayBuffer`
+- Remote `https://` URLs — both providers declare `supportedUrls = {}`, so the AI SDK downloads the image itself and delivers inline data to the provider; remote images work end to end through the temp-file path below
+- AI SDK v7 tagged file data (`{ type: 'data' | 'url' }`)
+
+**Not supported:**
+
+- `file://` URLs — rejected with an `unsupported` warning in both modes
+- Non-image `{ type: 'file' }` parts — skipped with an `unsupported` warning
+- Tagged `'text'` and `'reference'` file data for images — skipped with a warning
+- Raw HTTP(S) URL shapes that reach the exec provider directly, bypassing the AI SDK's download step — these produce an `unsupported` warning
+
+**How it works:**
+
+- Image bytes are written to temporary files
+- Passed to Codex via the `--image` flag (exec mode) or as `localImage` inputs (app-server mode)
+- Temp files are automatically cleaned up after the request completes
 
 ### Usage Tracking
 
-Currently returns `{ inputTokens: 0, outputTokens: 0, totalTokens: 0 }` for all requests. This is a Codex CLI limitation where `turn.completed` events don't consistently populate usage statistics.
+Both modes report real token usage from Codex events (`turn.completed` in exec mode, `thread/tokenUsage/updated` notifications in app-server mode), including cached input tokens.
+
+Notes:
+
+- With AI SDK v7, `result.usage` aggregates **all steps**; use `result.finalStep.usage` for final-step-only numbers.
+- Detailed fields live under `usage.inputTokenDetails` (e.g. `cacheReadTokens`) and `usage.outputTokenDetails` (e.g. `reasoningTokens`); the legacy top-level `cachedInputTokens` / `reasoningTokens` aliases were removed by AI SDK 7.
+- If Codex omits usage data for a turn, the provider reports zeros rather than failing.
 
 ### Streaming
 
-**Status:** Not currently supported with `--experimental-json` format (expected in future Codex CLI releases)
+Streaming granularity differs by mode:
 
-The `--experimental-json` output format (introduced in Codex CLI on Sept 25, 2025) currently only emits `item.completed` events with full text content. Incremental streaming via `item.updated` or delta events is **not yet implemented** by OpenAI.
+- **`codexAppServer` (recommended for streaming):** true incremental text deltas via `item/agentMessage/delta` notifications — `streamText()` emits progressively.
+- **`codexExec`:** Codex's `--experimental-json` output emits events (`thread.started`, `turn.completed`, `item.completed`) rather than text deltas, so `streamText()` works functionally but delivers the full response in a single chunk once generation completes. The provider reads the final assistant text from the `item.completed` event.
 
-**What this means:**
+Tool calls and results stream in real time in both modes (with `providerExecuted: true`), but tool _output_ streaming is limited: exec mode delivers tool output in the final `tool-result` event, and app-server mode surfaces output deltas only when Codex emits delta notifications.
 
-- `streamText()` works functionally but delivers the entire response in a single chunk after generation completes
-- No incremental text deltas - you wait for the full response, then receive it all at once
-- The AI SDK's streaming interface is supported, but actual incremental streaming is not available
+If OpenAI adds delta events to the exec JSON output format, this provider will surface them in exec mode as well.
 
-**Future support:**
-The Codex CLI commit message (344d4a1d) explicitly states: "or other item types like `item.output_delta` when we need streaming" and notes "more event types and item types to come."
+### Unsupported AI SDK Parameters
 
-When OpenAI adds streaming support to the experimental JSON format, this provider will be updated to handle those events and enable true incremental streaming.
+Codex CLI does not accept sampling and generation-control parameters. The provider ignores these with an `unsupported` warning: `temperature`, `topP`, `topK`, `maxOutputTokens`, `presencePenalty`, `frequencyPenalty`, `stopSequences`, `seed`.
 
-### Color Output
+AI SDK-defined `tools` / `toolChoice` are also not forwarded — Codex executes its own tools (exec, patch, web_search, MCP tools) autonomously and cannot call back into SDK tool implementations. (`toolChoice: 'auto'` is ignored without a warning, since AI SDK v7 sends it by default.) Use Codex MCP servers (including `createSdkMcpServer()` in app-server mode) to expose your own capabilities instead.
 
-When using `color: 'never'` mode (recommended for parsing), Codex CLI still includes ANSI control sequences in some log lines. The provider filters these out, but it's not 100% reliable.
+The top-level `reasoning` call option **is** supported and maps to Codex reasoning effort in both modes; see [docs/ai-sdk-v7/configuration.md](docs/ai-sdk-v7/configuration.md#reasoning-precedence).

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm i ai@^6 ai-sdk-provider-codex-cli@ai-sdk-v6
 npm i ai@^5.0.0 ai-sdk-provider-codex-cli@ai-sdk-v5
 ```
 
-> **⚠️ Codex CLI Version**: Requires the current stable Codex CLI **0.130.x** for full support of both provider modes (`codexExec` and `codexAppServer`). This package pins its optional `@openai/codex` dependency to `^0.130.0`, the latest non-alpha release validated for this release line. If you supply your own Codex CLI (global install or custom `codexPath`), check it with `codex --version` and upgrade if needed.
+> **⚠️ Codex CLI Version**: Requires the current stable Codex CLI **0.142.x** for full support of both provider modes (`codexExec` and `codexAppServer`). This package pins its optional `@openai/codex` dependency to `^0.142.5`, the latest non-alpha release validated for this release line. If you supply your own Codex CLI (global install or custom `codexPath`), check it with `codex --version` and upgrade if needed.
 >
 > ```bash
 > npm i -g @openai/codex@latest
@@ -100,7 +100,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.130.0',
+    minCodexVersion: '0.142.5',
     autoApprove: false,
     personality: 'pragmatic',
   },

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ for await (const part of result.stream) {
     console.log('🔧 Tool:', part.toolName);
   }
   if (part.type === 'tool-result') {
-    console.log('✅ Result:', part.result);
+    console.log('✅ Result:', part.output);
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ console.log(object);
 - Safe defaults for non‑interactive automation (`on-failure`, `workspace-write`, `--skip-git-repo-check`)
 - Fallback to `npx @openai/codex` when not on PATH (`allowNpx`)
 - Usage tracking from experimental JSON event format
-- **Image support** - Local binary images in both providers, plus remote HTTP/HTTPS image URLs in app-server mode
+- **Image support** - Local binary images in both providers; remote HTTP/HTTPS image URLs work via AI SDK download
 
 ### Image Support
 
@@ -215,8 +215,9 @@ console.log(text);
 
 **Remote image URLs:**
 
-- `codexExec` mode: HTTP/HTTPS image URLs are not supported (provide binary/image data)
-- `codexAppServer` mode: HTTP/HTTPS image URLs are supported and forwarded to app-server as remote image inputs
+- Pass remote images as `{ type: 'file', data: new URL('https://...'), mediaType: 'image/png' }` message parts in either mode
+- Both providers declare `supportedUrls = {}`, so the AI SDK downloads the URL itself and hands the provider the bytes, which flow through the same temp-file path as local images
+- Native URL passthrough (sending the URL for Codex to fetch server-side) is deferred until the Codex app-server verifiably accepts remote image URLs
 
 Local image data is written to temporary files and passed to Codex CLI via `--image` (or app-server `localImage`). Temp files are automatically cleaned up after each request.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ const first = await generateText({
   },
 });
 
-const threadId = first.providerMetadata?.['codex-app-server']?.threadId;
+const threadId = first.finalStep.providerMetadata?.['codex-app-server']?.threadId;
 
 const second = await generateText({
   model: provider('gpt-5.5'),
@@ -199,7 +199,7 @@ const { text } = await generateText({
       role: 'user',
       content: [
         { type: 'text', text: 'What do you see in this image?' },
-        { type: 'image', image: imageBuffer, mimeType: 'image/png' },
+        { type: 'file', data: imageBuffer, mediaType: 'image/png' },
       ],
     },
   ],

--- a/README.md
+++ b/README.md
@@ -171,12 +171,12 @@ console.log(object);
 - Backward-compatible aliases: `codexCli` / `createCodexCli` map to exec mode
 - Model discovery via `listModels()` / `provider.listModels()` — available slugs follow your installed Codex CLI
 - Streaming and non‑streaming
-- **Configurable logging** (v0.5.0+) - Verbose mode, custom loggers, or silent operation
-- **Tool streaming support** (v0.3.0+) - Monitor autonomous tool execution in real-time
-- **Native JSON Schema support** via `--output-schema` (API-enforced with `strict: true`)
+- **Configurable logging** - Verbose mode, custom loggers, or silent operation
+- **Tool streaming support** - Monitor autonomous tool execution in real-time
+- **Native JSON Schema support** via `--output-schema` (exec) / the `outputSchema` turn parameter (app-server)
 - JSON object generation with Zod schemas (100-200 fewer tokens per request vs prompt engineering)
 - Safe defaults for non‑interactive automation (`on-failure`, `workspace-write`, `--skip-git-repo-check`)
-- Fallback to `npx @openai/codex` when not on PATH (`allowNpx`)
+- Fallback to `npx -y @openai/codex` when the local `@openai/codex` package can't be resolved (`allowNpx`)
 - Usage tracking from experimental JSON event format
 - **Image support** - Local binary images in both providers; remote HTTP/HTTPS image URLs work via AI SDK download
 
@@ -217,13 +217,13 @@ console.log(text);
 
 - Pass remote images as `{ type: 'file', data: new URL('https://...'), mediaType: 'image/png' }` message parts in either mode
 - Both providers declare `supportedUrls = {}`, so the AI SDK downloads the URL itself and hands the provider the bytes, which flow through the same temp-file path as local images
-- Native URL passthrough (sending the URL for Codex to fetch server-side) is deferred until the Codex app-server verifiably accepts remote image URLs
+- Raw URL shapes that bypass the AI SDK's download step are warned and skipped in exec mode; app-server mode forwards them to Codex as-is, but the SDK download route above is the supported path
 
 Local image data is written to temporary files and passed to Codex CLI via `--image` (or app-server `localImage`). Temp files are automatically cleaned up after each request.
 
 See [examples/exec/image-support.mjs](examples/exec/image-support.mjs) and [examples/app-server/image-support.mjs](examples/app-server/image-support.mjs) for complete working examples.
 
-### Tool Streaming (v0.3.0+)
+### Tool Streaming
 
 The provider supports comprehensive tool streaming, enabling real-time monitoring of Codex CLI's autonomous tool execution:
 
@@ -256,11 +256,11 @@ for await (const part of result.stream) {
 **Current behavior:**
 
 - `codexExec`: tool outputs are delivered in final `tool-result` events.
-- `codexAppServer`: when Codex emits tool output delta notifications, the provider surfaces `tool-result` parts with `result.type === 'output-delta'` during streaming.
+- `codexAppServer`: when Codex emits tool output delta notifications, the provider surfaces `tool-result` parts whose `output.type === 'output-delta'` during streaming.
 
 See `examples/exec/streaming-tool-calls.mjs`, `examples/exec/streaming-multiple-tools.mjs`, and their app-server counterparts under `examples/app-server/`.
 
-### Logging Configuration (v0.5.0+)
+### Logging Configuration
 
 Control logging verbosity and integrate with your observability stack:
 
@@ -349,17 +349,17 @@ When OpenAI adds streaming support to `codex exec --experimental-json`, this pro
 
 ## Configuration (high level)
 
-- `allowNpx`: If true, falls back to `npx -y @openai/codex` when Codex is not on PATH
+- `allowNpx`: The provider prefers the locally installed `@openai/codex` package; when it can't be resolved, `allowNpx: true` falls back to `npx -y @openai/codex` (otherwise a `codex` binary on PATH is used)
 - `cwd`: Working directory for Codex
 - `addDirs`: Extra directories Codex may read/write (repeats `--add-dir`)
 - Autonomy/sandbox:
   - `fullAuto` (equivalent to `--full-auto`)
   - `dangerouslyBypassApprovalsAndSandbox` (bypass approvals and sandbox; dangerous)
   - Otherwise the provider writes `-c approval_policy=...` and `-c sandbox_mode=...` for you; defaults to `on-failure` and `workspace-write`
-- `skipGitRepoCheck`: enable by default for CI/non‑repo contexts
+- `skipGitRepoCheck`: on by default (pass `false` to keep Codex's git-repo check for CI/non‑repo safety)
 - `color`: `always` | `never` | `auto`
 - `outputLastMessageFile`: by default the provider sets a temp path and reads it to capture final text reliably
-- Logging (v0.5.0+):
+- Logging:
   - `verbose`: Enable debug/info logs (default: `false` for clean output)
   - `logger`: Custom logger object or `false` to disable all logging
 
@@ -396,7 +396,7 @@ Local MCP security defaults:
 - Without `cacheKey`, SDK MCP server/tool function identity participates in persistent keying to avoid conflating closure-dependent tool behavior.
 - Use `createSdkMcpServer({ cacheKey })` when you intentionally recreate equivalent SDK MCP definitions per call and want stable persistent model reuse.
 
-## Model Parameters & Advanced Options (v0.4.0+)
+## Model Parameters & Advanced Options
 
 Control reasoning effort, verbosity, and advanced Codex features at model creation time:
 
@@ -448,7 +448,7 @@ Nested override objects are flattened to dotted keys (e.g., the example above em
 `-c sandbox_workspace_write.network_access=true`). Arrays are serialized to JSON strings.
 MCP server env/header objects flatten the same way (e.g., `mcp_servers.docs.http_headers.x-tenant=acme`).
 
-### Per-call overrides via `providerOptions` (v0.4.0+)
+### Per-call overrides via `providerOptions`
 
 Override these parameters for individual AI SDK calls using the `providerOptions` map. Per-call
 values take precedence over constructor defaults while leaving other settings intact.
@@ -521,7 +521,7 @@ const response = await generateText({
 - Codex `--experimental-json` mode emits events rather than streaming deltas; streaming typically yields a final chunk. The CLI provides the final assistant text in the `item.completed` event, which this provider reads and emits at the end.
 - Some AI SDK parameters are unsupported by Codex CLI (e.g., temperature/topP/penalties); the provider surfaces warnings and ignores them
 
-### JSON Schema Limitations (v0.2.0+)
+### JSON Schema Limitations
 
 **⚠️ Important:** OpenAI strict mode has limitations:
 

--- a/README.md
+++ b/README.md
@@ -512,8 +512,7 @@ const response = await generateText({
 
 ## Zod Compatibility
 
-- Peer dependency: `zod@^3.25.76 || ^4.1.8`
-- Validation logic normalizes v3/v4 error shapes
+- Peer dependency: `zod@^4.1.8` (Zod 4 only; Zod 3 is not supported)
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![npm version](https://img.shields.io/npm/v/ai-sdk-provider-codex-cli.svg)](https://www.npmjs.com/package/ai-sdk-provider-codex-cli)
 [![npm downloads](https://img.shields.io/npm/dm/ai-sdk-provider-codex-cli.svg)](https://www.npmjs.com/package/ai-sdk-provider-codex-cli)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-![Node >= 18](https://img.shields.io/badge/node-%3E%3D18-43853d?logo=node.js&logoColor=white)
-![AI SDK v6](https://img.shields.io/badge/AI%20SDK-v6-000?logo=vercel&logoColor=white)
-![Modules: ESM + CJS](https://img.shields.io/badge/modules-ESM%20%2B%20CJS-3178c6)
+![Node >= 22](https://img.shields.io/badge/node-%3E%3D22-43853d?logo=node.js&logoColor=white)
+![AI SDK v7](https://img.shields.io/badge/AI%20SDK-v7-000?logo=vercel&logoColor=white)
+![Modules: ESM only](https://img.shields.io/badge/modules-ESM%20only-3178c6)
 ![TypeScript](https://img.shields.io/badge/TypeScript-blue)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/ben-vargas/ai-sdk-provider-codex-cli/issues)
 [![Latest Release](https://img.shields.io/github/v/release/ben-vargas/ai-sdk-provider-codex-cli?display_name=tag)](https://github.com/ben-vargas/ai-sdk-provider-codex-cli/releases/latest)
 
-A community provider for Vercel AI SDK v6 that integrates OpenAI's Codex CLI with current GPT models such as `gpt-5.5`, `gpt-5.2`, and `gpt-5.1`, plus Codex-specific slugs like `gpt-5.3-codex`, `gpt-5.2-codex`, `*-codex-max`, and `*-codex-mini`, using your ChatGPT Plus/Pro subscription.
+A community provider for Vercel AI SDK v7 that integrates OpenAI's Codex CLI (for example `gpt-5.5`) using your ChatGPT Plus/Pro subscription. Available model slugs follow whatever your installed Codex CLI exposes — use `listModels()` / `provider.listModels()` to discover them.
 
 This package ships two provider modes:
 
@@ -20,20 +20,22 @@ This package ships two provider modes:
 - Works with `generateText`, `streamText`, and `generateObject`
 - Uses ChatGPT OAuth from `codex login` (tokens in `~/.codex/auth.json`) or `OPENAI_API_KEY`
 - Node-only (spawns a local process); supports CI and local dev
-- **v1.0.0**: AI SDK v6 stable migration with LanguageModelV3 interface
-- **v0.5.0**: Adds comprehensive logging system with verbose mode and custom logger support
-- **v0.3.0**: Adds comprehensive tool streaming support for monitoring autonomous tool execution
+- Requires Node.js >= 22; published as an ESM-only package
+- **v2.0.0**: AI SDK v7 migration with the native LanguageModelV4 provider spec (package line 2.x)
+- **v1.0.0**: AI SDK v6 migration with the LanguageModelV3 interface (now on the `ai-sdk-v6` tag)
 
 ## Version Compatibility
 
-| Provider Version | AI SDK Version | NPM Tag     | NPM Installation                                      |
-| ---------------- | -------------- | ----------- | ----------------------------------------------------- |
-| 1.x.x            | v6             | `latest`    | `npm i ai-sdk-provider-codex-cli ai@^6.0.0`           |
-| 0.x.x            | v5             | `ai-sdk-v5` | `npm i ai-sdk-provider-codex-cli@ai-sdk-v5 ai@^5.0.0` |
+| Package line      | AI SDK | npm tag               | Git branch  | Status                       |
+| ----------------- | ------ | --------------------- | ----------- | ---------------------------- |
+| 2.x               | v7     | `latest`, `ai-sdk-v7` | `main`      | Active development           |
+| 1.x               | v6     | `ai-sdk-v6`           | `ai-sdk-v6` | Maintenance                  |
+| 0.7.x             | v5     | `ai-sdk-v5`           | `ai-sdk-v5` | Maintenance / critical fixes |
+| `0.1.0-ai-sdk-v4` | v4     | `ai-sdk-v4`           | `ai-sdk-v4` | Frozen                       |
 
 ## Installation
 
-### For AI SDK v6 (default)
+### For AI SDK v7 (default)
 
 1. Install and authenticate Codex CLI
 
@@ -42,10 +44,18 @@ npm i -g @openai/codex
 codex login   # or set OPENAI_API_KEY
 ```
 
-2. Install provider and AI SDK v6
+2. Install provider and AI SDK v7
 
 ```bash
 npm i ai ai-sdk-provider-codex-cli
+```
+
+> **Requirements:** Node.js >= 22. This package is ESM-only (no CommonJS build); load it with `import` (or dynamic `import()` from CJS).
+
+### For AI SDK v6
+
+```bash
+npm i ai@^6 ai-sdk-provider-codex-cli@ai-sdk-v6
 ```
 
 ### For AI SDK v5
@@ -54,7 +64,7 @@ npm i ai ai-sdk-provider-codex-cli
 npm i ai@^5.0.0 ai-sdk-provider-codex-cli@ai-sdk-v5
 ```
 
-> **⚠️ Codex CLI Version**: Requires the current stable Codex CLI **0.130.x** for full support of both provider modes (`codexExec` and `codexAppServer`). This package pins its optional `@openai/codex` dependency to `^0.130.0`, the latest non-alpha release validated for this maintenance update. If you supply your own Codex CLI (global install or custom `codexPath`), check it with `codex --version` and upgrade if needed.
+> **⚠️ Codex CLI Version**: Requires the current stable Codex CLI **0.130.x** for full support of both provider modes (`codexExec` and `codexAppServer`). This package pins its optional `@openai/codex` dependency to `^0.130.0`, the latest non-alpha release validated for this release line. If you supply your own Codex CLI (global install or custom `codexPath`), check it with `codex --version` and upgrade if needed.
 >
 > ```bash
 > npm i -g @openai/codex@latest
@@ -154,11 +164,12 @@ console.log(object);
 
 ## Features
 
-- AI SDK v6 compatible (LanguageModelV3)
+- AI SDK v7 compatible (native LanguageModelV4 provider spec)
 - Dual provider architecture:
   - `codexExec` / `createCodexExec` for `codex exec`
   - `codexAppServer` / `createCodexAppServer` for `codex app-server`
 - Backward-compatible aliases: `codexCli` / `createCodexCli` map to exec mode
+- Model discovery via `listModels()` / `provider.listModels()` — available slugs follow your installed Codex CLI
 - Streaming and non‑streaming
 - **Configurable logging** (v0.5.0+) - Verbose mode, custom loggers, or silent operation
 - **Tool streaming support** (v0.3.0+) - Monitor autonomous tool execution in real-time
@@ -224,7 +235,7 @@ const result = await streamText({
   prompt: 'List files and count lines in the largest one',
 });
 
-for await (const part of result.fullStream) {
+for await (const part of result.stream) {
   if (part.type === 'tool-call') {
     console.log('🔧 Tool:', part.toolName);
   }
@@ -298,7 +309,7 @@ const silentModel = codexExec('gpt-5.5', {
 
 **Default Logger:** Adds level tags `[DEBUG]`, `[INFO]`, `[WARN]`, `[ERROR]` to console output. Use a custom logger or `logger: false` if you need different formatting.
 
-See `examples/exec/logging-*.mjs` and `examples/app-server/logging-*.mjs` for complete examples, and [docs/ai-sdk-v5/guide.md](docs/ai-sdk-v5/guide.md) for detailed configuration.
+See `examples/exec/logging-*.mjs` and `examples/app-server/logging-*.mjs` for complete examples, and [docs/ai-sdk-v7/guide.md](docs/ai-sdk-v7/guide.md) for detailed configuration.
 
 ### Text Streaming behavior
 
@@ -319,11 +330,11 @@ When OpenAI adds streaming support to `codex exec --experimental-json`, this pro
 ## Documentation
 
 - Getting started, configuration, and troubleshooting live in `docs/`:
-  - [docs/ai-sdk-v5/guide.md](docs/ai-sdk-v5/guide.md) – full usage guide and examples
-  - [docs/ai-sdk-v5/configuration.md](docs/ai-sdk-v5/configuration.md) – all settings and how they map to CLI flags
-  - [docs/ai-sdk-v5/troubleshooting.md](docs/ai-sdk-v5/troubleshooting.md) – common issues and fixes
-  - [docs/ai-sdk-v5/limitations.md](docs/ai-sdk-v5/limitations.md) – known constraints and behavior differences
-  - [docs/ai-sdk-v5/migration-app-server-v2.md](docs/ai-sdk-v5/migration-app-server-v2.md) – app-server v2 migration notes
+  - [docs/ai-sdk-v7/guide.md](docs/ai-sdk-v7/guide.md) – full usage guide and examples
+  - [docs/ai-sdk-v7/configuration.md](docs/ai-sdk-v7/configuration.md) – all settings and how they map to CLI flags
+  - [docs/ai-sdk-v7/troubleshooting.md](docs/ai-sdk-v7/troubleshooting.md) – common issues and fixes
+  - [docs/ai-sdk-v7/limitations.md](docs/ai-sdk-v7/limitations.md) – known constraints and behavior differences
+  - [docs/ai-sdk-v7/migration-v6-to-v7.md](docs/ai-sdk-v7/migration-v6-to-v7.md) – migrating from the 1.x (AI SDK v6) package line
 - See [examples/](examples/) for runnable scripts covering core usage, streaming, permissions/sandboxing, and object generation.
 - Validation helpers:
   - `npm run validate:docs` checks markdown links and example command paths
@@ -351,7 +362,7 @@ When OpenAI adds streaming support to `codex exec --experimental-json`, this pro
   - `verbose`: Enable debug/info logs (default: `false` for clean output)
   - `logger`: Custom logger object or `false` to disable all logging
 
-See [docs/ai-sdk-v5/configuration.md](docs/ai-sdk-v5/configuration.md) for the full list and examples.
+See [docs/ai-sdk-v7/configuration.md](docs/ai-sdk-v7/configuration.md) for the full list and examples.
 
 ### App-server settings highlights
 
@@ -361,7 +372,7 @@ See [docs/ai-sdk-v5/configuration.md](docs/ai-sdk-v5/configuration.md) for the f
 - `requestTimeoutMs`: default per-request JSON-RPC timeout
 - `idleTimeoutMs`: close idle app-server process after inactivity
 - `minCodexVersion`: minimum supported app-server version (semver)
-- `includeRawChunks`: emit raw JSON-RPC notifications as `raw` stream parts by default
+- `includeRawChunks`: emit raw JSON-RPC notifications as `raw` stream parts by default (per call, prefer the standard AI SDK v7 option `include: { rawChunks: true }` on `streamText`)
 - `serverRequests`: typed handlers for server-initiated JSON-RPC requests
 - `autoApprove`: default approval response when no custom handler is provided (covers command execution, file changes, skills, and MCP tool call approvals via `mcpServer/elicitation/request` on Codex >= 0.139)
 - `persistExtendedHistory`: request extended thread history persistence
@@ -369,7 +380,7 @@ See [docs/ai-sdk-v5/configuration.md](docs/ai-sdk-v5/configuration.md) for the f
 - `resume`: shorthand to resume an existing thread id
 - `onSessionCreated`: receive a session object for `injectMessage()` / `interrupt()`
 
-Per-call app-server overrides use `providerOptions['codex-app-server']` (for example `threadId`, `threadMode`, `includeRawChunks`, `personality`, `approvalPolicy`, `sandboxPolicy`, `serverRequests`, `configOverrides`).
+Per-call app-server overrides use `providerOptions['codex-app-server']` (for example `threadId`, `threadMode`, `includeRawChunks`, `personality`, `approvalPolicy`, `sandboxPolicy`, `serverRequests`, `configOverrides`). Raw chunk emission can also be requested per call with the standard AI SDK v7 option `include: { rawChunks: true }`.
 
 Additional app-server helpers:
 
@@ -475,7 +486,9 @@ const response = await generateText({
 });
 ```
 
-**Precedence:** `providerOptions['codex-cli']` > constructor `CodexCliSettings` > Codex CLI defaults.
+**Precedence:** `providerOptions['codex-cli']` > top-level `reasoning` call option > constructor `CodexCliSettings` > Codex CLI defaults.
+
+The AI SDK v7 top-level `reasoning` option (`'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'`) maps directly to Codex reasoning effort in both provider modes; provider-specific effort options (`reasoningEffort` for exec, `effort` for app-server) win when both are set, and `'provider-default'` leaves your configured default untouched.
 
 App-server per-call overrides use `providerOptions['codex-app-server']`:
 
@@ -499,12 +512,12 @@ const response = await generateText({
 
 ## Zod Compatibility
 
-- Peer supports `zod@^3 || ^4`
+- Peer dependency: `zod@^3.25.76 || ^4.1.8`
 - Validation logic normalizes v3/v4 error shapes
 
 ## Limitations
 
-- Node ≥ 18, local process only (no Edge)
+- Node ≥ 22, ESM-only, local process only (no Edge)
 - Codex `--experimental-json` mode emits events rather than streaming deltas; streaming typically yields a final chunk. The CLI provides the final assistant text in the `item.completed` event, which this provider reads and emits at the end.
 - Some AI SDK parameters are unsupported by Codex CLI (e.g., temperature/topP/penalties); the provider surfaces warnings and ignores them
 

--- a/docs/ai-sdk-v7/configuration.md
+++ b/docs/ai-sdk-v7/configuration.md
@@ -1,0 +1,313 @@
+# Configuration Reference
+
+This package ships two provider modes:
+
+- **`codexExec`** wraps the `codex exec` CLI in non‑interactive mode and maps settings to CLI flags/config overrides. Per-call overrides use `providerOptions['codex-cli']`.
+- **`codexAppServer`** speaks JSON-RPC to a persistent `codex app-server` process. Per-call overrides use `providerOptions['codex-app-server']`.
+
+Model IDs are discovered, not hard-coded: use `listModels()` / `provider.listModels()` (see [guide.md](./guide.md#discovering-models)). Examples below use `gpt-5.5` as a placeholder.
+
+## Exec Provider Settings (`codexExec`)
+
+- `allowNpx` (boolean): If true, runs `npx -y @openai/codex` when Codex isn’t found on PATH.
+- `codexPath` (string): Explicit path to Codex CLI executable (e.g. `/opt/homebrew/bin/codex`) or JS entry (`bin/codex.js`), bypassing PATH resolution.
+- `cwd` (string): Working directory for the spawned process.
+- `addDirs` (string[]): Additional directories Codex can read/write. Emits one `--add-dir <path>` per entry (useful in monorepos or when sharing resources across packages).
+- `color` ('always' | 'never' | 'auto'): Controls ANSI color emission.
+- `skipGitRepoCheck` (boolean): When true, passes `--skip-git-repo-check`.
+- `fullAuto` (boolean): Sets `--full-auto` (low-friction sandboxed execution).
+- `dangerouslyBypassApprovalsAndSandbox` (boolean): Maps to `--dangerously-bypass-approvals-and-sandbox`.
+- `approvalMode` ('untrusted' | 'on-failure' | 'on-request' | 'never'): Applied via `-c approval_policy=...`.
+- `sandboxMode` ('read-only' | 'workspace-write' | 'danger-full-access'): Applied via `-c sandbox_mode=...`.
+- `outputLastMessageFile` (string): File path to write the last agent message. If omitted, a temp file is created.
+- `env` (Record<string,string>): Extra env vars for the child process (e.g., `OPENAI_API_KEY`).
+- `verbose` (boolean): Enable verbose logging mode. When `true`, enables `debug` and `info` log levels. When `false` (default), only `warn` and `error` are logged.
+- `logger` (Logger | false): Custom logger object or `false` to disable logging entirely. Logger must implement four methods: `debug`, `info`, `warn`, and `error`. Default uses `console.*` methods.
+- `rmcpClient` (boolean): Enable the RMCP client so HTTP-based MCP servers can be reached (`-c features.rmcp_client=true`).
+- `mcpServers` (Record<string, McpServerConfig>): Define MCP servers (stdio or HTTP). Keys are server names; values follow the shapes below.
+
+### Reasoning & Verbosity
+
+- **`reasoningEffort`** ('none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'): Controls reasoning depth for reasoning-capable models. Higher effort produces more thorough reasoning at the cost of latency. Maps to `-c model_reasoning_effort=<value>`.
+  - Which effort levels a given model accepts is owned by Codex/OpenAI and varies by model family; check your Codex CLI docs for the models `listModels()` returns.
+  - `'none'` is the "no extra reasoning" level for newer model families; `'minimal'` is retained as a backwards-compatible alias used by older GPT‑5 slugs.
+  - `'xhigh'` is only exposed on model families that support it.
+  - The AI SDK v7 top-level `reasoning` call option maps onto this setting — see [Reasoning Precedence](#reasoning-precedence).
+- **`reasoningSummary`** ('auto' | 'detailed'): Controls reasoning summary detail level. **Note:** Despite API error messages claiming 'concise' and 'none' are valid, they are rejected with 400 errors. Only 'auto' and 'detailed' work. Maps to `-c model_reasoning_summary=<value>`.
+- **`reasoningSummaryFormat`** ('none' | 'experimental'): Controls reasoning summary format (experimental). Maps to `-c model_reasoning_summary_format=<value>`.
+- **`modelVerbosity`** ('low' | 'medium' | 'high'): Controls output length/detail for models that support `model_verbosity`; Codex-specific slugs ignore it (the CLI disables verbosity for those model families). Maps to `-c model_verbosity=<value>`.
+
+### Advanced Codex Features
+
+- **`profile`** (string): Configuration profile from config.toml to specify default options. Maps to `--profile <name>`.
+- **`oss`** (boolean): Use OSS provider (experimental). Maps to `--oss`.
+- **`webSearch`** (boolean): Enable web search tool for the model. Maps to `-c tools.web_search=true`.
+
+### MCP Servers
+
+- **`rmcpClient`** (boolean): Enables the RMCP client for HTTP-based MCP servers. Maps to `-c features.rmcp_client=true`.
+- **`mcpServers`** (Record<string, McpServerConfig>): Define MCP servers by name.
+  - Common fields: `enabled?`, `startupTimeoutSec?`, `toolTimeoutSec?`, `enabledTools?`, `disabledTools?`.
+  - **Stdio servers** (`transport: 'stdio'`): `command` (required), `args?`, `env?`, `cwd?`.
+  - **HTTP/RMCP servers** (`transport: 'http'`): `url` (required), `bearerToken?`, `bearerTokenEnvVar?`, `httpHeaders?`, `envHttpHeaders?`.
+
+Example:
+
+```ts
+const model = codexExec('gpt-5.5', {
+  rmcpClient: true,
+  mcpServers: {
+    // Stdio MCP
+    repo: {
+      transport: 'stdio',
+      command: 'node',
+      args: ['tools/repo-mcp.js'],
+      env: { API_KEY: process.env.REPO_KEY ?? '' },
+      enabledTools: ['list', 'read'],
+    },
+    // HTTP/RMCP
+    docs: {
+      transport: 'http',
+      url: 'https://mcp.internal/api',
+      bearerTokenEnvVar: 'MCP_BEARER',
+      httpHeaders: { 'x-tenant': 'acme' },
+    },
+  },
+});
+```
+
+The app-server provider additionally accepts in-process SDK MCP servers created with `createSdkMcpServer()` / `tool()` as `mcpServers` values.
+
+### Generic Config Overrides
+
+- **`configOverrides`** (Record<string, string | number | boolean | object>): Generic Codex CLI config overrides. Allows setting any config value without updating the provider. Each entry maps to `-c <key>=<value>`.
+
+Examples (nested objects are flattened to dotted keys):
+
+```ts
+const overrides = {
+  experimental_resume: '/tmp/session.jsonl', // string
+  hide_agent_reasoning: true, // boolean
+  model_context_window: 200000, // number
+  sandbox_workspace_write: { network_access: true }, // object → -c sandbox_workspace_write.network_access=true
+  'model_providers.custom.base_url': 'http://localhost:8000', // nested config path
+};
+```
+
+Values are serialized:
+
+- string → raw string
+- number/boolean → String(value)
+- object → flattened to dotted keys (recursively)
+- array → JSON.stringify(value)
+- non-plain objects (Date, RegExp, Map, etc.) → JSON.stringify(value)
+
+### Per-call Overrides (`providerOptions['codex-cli']`)
+
+Use AI SDK `providerOptions` to override Codex parameters for a single request without modifying the model instance. The provider parses the `codex-cli` entry and applies the keys below:
+
+- `reasoningEffort` → `model_reasoning_effort`
+- `reasoningSummary` → `model_reasoning_summary`
+- `reasoningSummaryFormat` → `model_reasoning_summary_format`
+- `textVerbosity` → `model_verbosity` (AI SDK naming; mirrors constructor `modelVerbosity`)
+- `addDirs` → appends `--add-dir` entries (merged with constructor `addDirs`)
+- `configOverrides` → merged with constructor-level overrides (per-call values win on key conflicts)
+- `mcpServers` → merged with constructor-level MCP servers (per-call values override per server)
+- `rmcpClient` → overrides constructor `rmcpClient`
+
+```ts
+import { generateText } from 'ai';
+import { codexExec } from 'ai-sdk-provider-codex-cli';
+
+const model = codexExec('gpt-5.5', {
+  reasoningEffort: 'medium',
+  modelVerbosity: 'medium',
+});
+
+await generateText({
+  model,
+  prompt: 'Compare the trade-offs of high vs. low verbosity.',
+  providerOptions: {
+    'codex-cli': {
+      reasoningEffort: 'high',
+      reasoningSummary: 'detailed',
+      textVerbosity: 'high',
+      configOverrides: {
+        'sandbox_workspace_write.network_access': true,
+      },
+    },
+  },
+});
+```
+
+**Precedence:** `providerOptions['codex-cli']` > constructor `CodexExecSettings` > Codex CLI defaults.
+
+### Flag Mapping
+
+#### Core Settings
+
+- `approvalMode` → `-c approval_policy=<mode>`
+- `sandboxMode` → `-c sandbox_mode=<mode>`
+- `skipGitRepoCheck` → `--skip-git-repo-check`
+- `fullAuto` → `--full-auto`
+- `dangerouslyBypassApprovalsAndSandbox` → `--dangerously-bypass-approvals-and-sandbox`
+- `color` → `--color <always|never|auto>`
+- `outputLastMessageFile` → `--output-last-message <path>`
+- `addDirs` → `--add-dir <path>` (emitted once per entry)
+
+#### Model Parameters
+
+- `reasoningEffort` → `-c model_reasoning_effort=<value>`
+- `reasoningSummary` → `-c model_reasoning_summary=<value>`
+- `reasoningSummaryFormat` → `-c model_reasoning_summary_format=<value>`
+- `modelVerbosity` → `-c model_verbosity=<value>`
+- `profile` → `--profile <name>`
+- `oss` → `--oss`
+- `webSearch` → `-c tools.web_search=true`
+- `configOverrides` → `-c <key>=<value>` (for each entry)
+
+#### MCP
+
+- `rmcpClient` → `-c features.rmcp_client=true`
+- `mcpServers` → `-c mcp_servers.<name>.<field>=<value>` for each field (e.g., `command`, `args`, `env.KEY`, `url`, `bearer_token_env_var`, `http_headers.Header-Name`).
+
+## App-Server Settings
+
+`createCodexAppServer({ defaultSettings })` and the per-model settings argument accept:
+
+**Process & connection**
+
+- `codexPath` (string): Explicit Codex CLI path, bypassing PATH resolution.
+- `cwd` (string): Working directory for the app-server process.
+- `env` (Record<string,string>): Extra env vars for the child process.
+- `connectionTimeoutMs` (number): `initialize` handshake timeout.
+- `requestTimeoutMs` (number): Default per-request JSON-RPC timeout.
+- `idleTimeoutMs` (number): Close an idle app-server process after inactivity.
+- `minCodexVersion` (string): Minimum supported app-server version (semver); the provider fails fast when the CLI is older.
+- `verbose` / `logger`: Same logging contract as exec mode.
+
+**Turn behavior**
+
+- `personality` ('none' | 'friendly' | 'pragmatic'): Codex response personality.
+- `effort` ('none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'): Reasoning effort for the turn; see [Reasoning Precedence](#reasoning-precedence).
+- `summary` ('auto' | 'concise' | 'detailed' | 'none'): Reasoning summary level (app-server protocol accepts all four).
+- `approvalPolicy`: 'untrusted' | 'on-failure' | 'on-request' | 'never' or a protocol-shaped object.
+- `sandboxPolicy`: 'read-only' | 'workspace-write' | 'danger-full-access' or a protocol-shaped object (e.g. `{ type: 'externalSandbox', networkAccess: 'enabled' }`).
+- `baseInstructions` / `developerInstructions` (string): Instruction overrides passed to the thread.
+
+**MCP & config**
+
+- `mcpServers` (Record<string, McpServerConfig | SdkMcpServer>): Stdio/HTTP MCP servers, or in-process SDK MCP servers from `createSdkMcpServer()`.
+- `rmcpClient` (boolean): Enable HTTP-based MCP clients.
+- `configOverrides`: Same shape and serialization as exec mode.
+
+**Sessions & streaming**
+
+- `threadMode` ('stateless' | 'persistent'): `stateless` (default) starts an ephemeral thread per call; `persistent` reuses one thread automatically.
+- `resume` (string): Shorthand to resume an existing thread id.
+- `persistExtendedHistory` (boolean): Request extended thread history persistence.
+- `includeRawChunks` (boolean): Emit raw JSON-RPC notifications as `raw` stream parts by default.
+- `onSessionCreated` (callback): Receives a live session object exposing `injectMessage()` and `interrupt()`.
+
+**Approvals**
+
+- `autoApprove` (boolean): Default approval response when no custom handler is provided (covers command execution, file changes, skills, and MCP tool call elicitations).
+- `serverRequests` (CodexAppServerRequestHandlers): Typed handlers for server-initiated JSON-RPC requests (command approvals, file-change approvals, skill approvals, MCP elicitations, dynamic tool calls, auth refresh, plus an `unhandled` fallback).
+
+### Per-call Overrides (`providerOptions['codex-app-server']`)
+
+Per-call keys mirror the settings above: `threadId`, `resume`, `threadMode`, `includeRawChunks`, `personality`, `effort`, `summary`, `approvalPolicy`, `sandboxPolicy`, `baseInstructions`, `developerInstructions`, `mcpServers`, `rmcpClient`, `configOverrides`, `autoApprove`, `persistExtendedHistory`, `serverRequests`, `onSessionCreated`.
+
+```ts
+import { generateText } from 'ai';
+import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
+
+const provider = createCodexAppServer();
+
+const response = await generateText({
+  model: provider('gpt-5.5'),
+  prompt: 'Continue this task.',
+  providerOptions: {
+    'codex-app-server': {
+      threadId: 'thr_existing',
+      personality: 'pragmatic',
+      approvalPolicy: 'on-request',
+      effort: 'high',
+    },
+  },
+});
+
+await provider.close();
+```
+
+**Precedence:** `providerOptions['codex-app-server']` > model/constructor `CodexAppServerSettings` > Codex defaults.
+
+Always call `provider.close()` (alias `dispose()`) when you are done; the app-server process is shared across calls and does not exit on its own before `idleTimeoutMs`.
+
+### Model Discovery
+
+- `listModels(options?)` — standalone helper; spins up a temporary app-server process. Options: `codexPath`, `env`, `cwd`, `minCodexVersion`, `modelProviders`, `connectionTimeoutMs`, `requestTimeoutMs`. Returns `{ models, defaultModel, nextCursor }`.
+- `provider.listModels(modelProviders?)` — queries through the provider's existing client process.
+
+## Reasoning Precedence
+
+AI SDK v7 adds a provider-agnostic top-level call option:
+
+```ts
+reasoning?: 'provider-default' | 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+```
+
+This provider maps it to Codex reasoning effort. The exact precedence, highest first:
+
+**Exec (`codexCli` / `codexExec`):**
+
+1. `providerOptions['codex-cli'].reasoningEffort`
+2. top-level `reasoning` (when it is not `'provider-default'`)
+3. constructor `reasoningEffort` setting
+4. Codex CLI default
+
+**App-server (`codexAppServer`):**
+
+1. `providerOptions['codex-app-server'].effort`
+2. top-level `reasoning` (when it is not `'provider-default'`)
+3. constructor/model `effort` setting
+4. Codex default
+
+Notes:
+
+- `reasoning: 'provider-default'` (or omitting the option) falls through to your provider-specific configuration — the provider does not send an effort override on your behalf.
+- If both the top-level option and a provider-specific option are set, the provider-specific value silently wins. When migrating to the top-level `reasoning` option, remove overlapping `reasoningEffort` / `effort` entries from `providerOptions` so your new configuration actually applies.
+- All current v7 `reasoning` values map 1:1 onto Codex effort levels. If a future AI SDK adds a value Codex does not understand, the provider emits an `unsupported` warning instead of failing the call.
+
+```ts
+await generateText({
+  model: provider('gpt-5.5'),
+  reasoning: 'low', // ignored in favor of providerOptions below
+  prompt: 'Quick sanity check.',
+  providerOptions: {
+    'codex-app-server': { effort: 'high' }, // wins
+  },
+});
+```
+
+## Defaults & Recommendations
+
+- Non‑interactive defaults (exec):
+  - `approvalMode: 'on-failure'`
+  - `sandboxMode: 'workspace-write'`
+  - `skipGitRepoCheck: true`
+- For strict automation in controlled environments:
+  - `fullAuto: true` OR `dangerouslyBypassApprovalsAndSandbox: true` (be careful!)
+- App-server: set `minCodexVersion` to the Codex CLI version you validated against, and always `await provider.close()`.
+
+## JSON Mode
+
+When the AI SDK request uses `responseFormat: { type: 'json' }` (as `generateObject` / `streamObject` do), the provider:
+
+1. Converts your Zod schema to JSON Schema format
+2. Sanitizes the schema (removes unsupported fields like `format`, `pattern`, `$schema`, etc.)
+3. Passes the schema via `--output-schema` (exec) or `outputSchema` (app-server) for native OpenAI strict mode enforcement
+4. The API returns guaranteed valid JSON matching your schema
+5. AI SDK validates the response with Zod
+
+OpenAI strict mode does not support optional fields or format validators — see [limitations.md](./limitations.md).

--- a/docs/ai-sdk-v7/guide.md
+++ b/docs/ai-sdk-v7/guide.md
@@ -7,7 +7,7 @@ This guide explains how to use the Codex CLI provider with Vercel AI SDK v7 for 
 - **AI SDK v7** (`ai@^7`) and `ai-sdk-provider-codex-cli@^2`
 - **Node.js 22 or later** (AI SDK v7 requirement)
 - **ESM only** — version 2.x of this package ships no CommonJS build. `require('ai-sdk-provider-codex-cli')` is not supported; use `import` (add `"type": "module"` to your `package.json` or use `.mjs` files)
-- **zod** peer dependency: `^3.25.76 || ^4.1.8`
+- **zod** peer dependency: `^4.1.8`
 - A working Codex CLI (`codex login` or `OPENAI_API_KEY`)
 
 Using AI SDK v6? Stay on the 1.x line: see [migration-v6-to-v7.md](./migration-v6-to-v7.md#staying-on-ai-sdk-v6).

--- a/docs/ai-sdk-v7/guide.md
+++ b/docs/ai-sdk-v7/guide.md
@@ -1,0 +1,379 @@
+# Codex CLI Provider – AI SDK v7 Guide
+
+This guide explains how to use the Codex CLI provider with Vercel AI SDK v7 for text generation, streaming, JSON object generation, and persistent app-server sessions.
+
+## Requirements
+
+- **AI SDK v7** (`ai@^7`) and `ai-sdk-provider-codex-cli@^2`
+- **Node.js 22 or later** (AI SDK v7 requirement)
+- **ESM only** — version 2.x of this package ships no CommonJS build. `require('ai-sdk-provider-codex-cli')` is not supported; use `import` (add `"type": "module"` to your `package.json` or use `.mjs` files)
+- **zod** peer dependency: `^3.25.76 || ^4.1.8`
+- A working Codex CLI (`codex login` or `OPENAI_API_KEY`)
+
+Using AI SDK v6? Stay on the 1.x line: see [migration-v6-to-v7.md](./migration-v6-to-v7.md#staying-on-ai-sdk-v6).
+
+## Getting Started
+
+1. Install Codex CLI and authenticate:
+
+```bash
+npm i -g @openai/codex
+codex login   # or set OPENAI_API_KEY
+```
+
+2. Install AI SDK v7 and this provider:
+
+```bash
+npm i ai@^7 ai-sdk-provider-codex-cli@^2
+```
+
+## Choosing a Provider Mode
+
+The package ships two provider modes:
+
+- **`codexExec`** (also `createCodexExec`): spawns a fresh `codex exec` process per call. Simple, stateless, no cleanup required.
+- **`codexAppServer`** (also `createCodexAppServer`): a persistent `codex app-server` JSON-RPC client. Shared process, true incremental streaming, optional stateful threads, model discovery, approvals, and local MCP tools. Call `provider.close()` when finished.
+
+The legacy `codexCli` / `createCodexCli` exports remain as aliases for exec mode.
+
+## Discovering Models
+
+Model slugs are owned by Codex/OpenAI and change independently of this package — do not hard-code a catalog. Query the models your installed Codex CLI actually offers:
+
+```js
+import { listModels } from 'ai-sdk-provider-codex-cli';
+
+const { models, defaultModel } = await listModels();
+console.log('default:', defaultModel?.id);
+console.log(models.map((m) => m.id));
+```
+
+`listModels()` starts a temporary app-server process. If you already hold an app-server provider, reuse its process instead:
+
+```js
+import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
+
+const provider = createCodexAppServer();
+const { models } = await provider.listModels();
+console.log(models.map((m) => m.id));
+await provider.close();
+```
+
+The examples in these docs use `gpt-5.5`, the default model returned by `model/list` at the time of writing. Substitute whatever `listModels()` returns for you.
+
+## Basic Usage
+
+```js
+import { generateText, streamText, generateObject } from 'ai';
+import { codexExec } from 'ai-sdk-provider-codex-cli';
+import { z } from 'zod';
+
+const model = codexExec('gpt-5.5', {
+  allowNpx: true,
+  skipGitRepoCheck: true,
+  approvalMode: 'on-failure',
+  sandboxMode: 'workspace-write',
+});
+
+// Text
+const { text } = await generateText({ model, prompt: 'Say hello in one word.' });
+
+// Streaming
+const { textStream } = await streamText({ model, prompt: 'Two short lines.' });
+for await (const chunk of textStream) process.stdout.write(chunk);
+
+// Object (JSON)
+const schema = z.object({ name: z.string(), age: z.number().int() });
+const { object } = await generateObject({ model, schema, prompt: 'Generate a user.' });
+```
+
+## Conversation History
+
+Use AI SDK messages to retain context:
+
+```js
+const messages = [
+  { role: 'user', content: 'My name is Dana.' },
+  { role: 'assistant', content: 'Hi Dana!' },
+  { role: 'user', content: 'What did I just tell you my name was?' },
+];
+const { text } = await generateText({ model, messages });
+```
+
+For long-running conversations, prefer app-server persistent threads (below) so Codex keeps server-side context instead of replaying a transcript each call.
+
+## System Instructions
+
+AI SDK v7 renamed the top-level `system` option to `instructions`, and **rejects `{ role: 'system' }` messages inside `messages` by default**:
+
+```js
+const { text } = await generateText({
+  model,
+  instructions: 'You are a terse assistant. Answer in one sentence.',
+  prompt: 'Why is the sky blue?',
+});
+```
+
+If you have persisted chats that already contain system messages, either move that text into `instructions`, or opt in to the old behavior with `allowSystemInMessages: true` (only for trusted, server-controlled messages). See [migration-v6-to-v7.md](./migration-v6-to-v7.md) for details.
+
+## Structured Output (JSON)
+
+The provider uses native `--output-schema` (exec) / `outputSchema` (app-server) with OpenAI strict mode for API-level JSON enforcement.
+
+**⚠️ Important limitations:**
+
+- Optional fields are **NOT supported** by OpenAI strict mode (all fields must be required)
+- Format validators (`.email()`, `.url()`, `.uuid()`) are stripped (use descriptions instead)
+- Pattern validators (`.regex()`) are stripped (use descriptions instead)
+
+See [limitations.md](./limitations.md) and [LIMITATIONS.md](../../LIMITATIONS.md) for full details.
+
+Tips:
+
+- Add clear field descriptions to your Zod schema (especially for format hints like "UUID format", "YYYY-MM-DD date")
+- All fields must be required (no `.optional()`)
+- Use descriptions instead of format validators
+- Keep constraints realistic for better adherence
+
+## Reasoning Effort
+
+AI SDK v7 adds a provider-agnostic, top-level `reasoning` option. This provider maps it to Codex reasoning effort:
+
+```js
+const { text } = await generateText({
+  model: codexExec('gpt-5.5', { allowNpx: true, skipGitRepoCheck: true }),
+  reasoning: 'high', // 'provider-default' | 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+  prompt: 'Prove that the square root of 2 is irrational.',
+});
+```
+
+Provider-specific options take precedence when both are present:
+
+- exec: `providerOptions['codex-cli'].reasoningEffort` wins over top-level `reasoning`
+- app-server: `providerOptions['codex-app-server'].effort` wins over top-level `reasoning`
+
+`reasoning: 'provider-default'` (or omitting the option) leaves your constructor settings and Codex defaults untouched. The full precedence chain is documented in [configuration.md](./configuration.md#reasoning-precedence).
+
+## Image Inputs
+
+Both providers accept image inputs for vision-capable models using the AI SDK v7 canonical `file` part:
+
+```js
+import { readFileSync } from 'node:fs';
+
+const { text } = await generateText({
+  model,
+  messages: [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'What do you see in this image?' },
+        { type: 'file', data: readFileSync('./screenshot.png'), mediaType: 'image/png' },
+      ],
+    },
+  ],
+});
+```
+
+- `mediaType` accepts a full IANA type (`'image/png'`) or a top-level segment (`'image'`).
+- Inline data (`Uint8Array`, `Buffer`, base64, `data:` URLs) is written to a temp file and passed to Codex (`--image` for exec, `localImage` for app-server); temp files are cleaned up after each request.
+- **Remote URLs:** the provider declares `supportedUrls = {}`, so the AI SDK downloads `https://` file parts itself and hands the provider inline data, which flows through the same temp-file path. Raw remote-URL shapes that bypass the SDK download produce an unsupported warning in exec mode.
+- Non-image files, `file://` URLs, file `reference` data, and `reasoning-file` / `custom` parts are not supported and produce warnings. See [limitations.md](./limitations.md).
+
+## Permissions & Sandbox
+
+The provider applies safe defaults for non‑interactive execution. You can override them per call via provider settings:
+
+- `fullAuto: true` → `--full-auto` (exec)
+- `dangerouslyBypassApprovalsAndSandbox: true` → `--dangerously-bypass-approvals-and-sandbox` (exec)
+- Otherwise, the exec provider writes config overrides: `-c approval_policy=...` and `-c sandbox_mode=...`; the app-server provider passes `approvalPolicy` / `sandboxPolicy` on the thread.
+
+Recommended defaults for CI/local automation:
+
+- `approvalMode: 'on-failure'`
+- `sandboxMode: 'workspace-write'`
+- `skipGitRepoCheck: true` (exec)
+
+### Approvals: SDK tools vs Codex-native
+
+Two distinct approval systems exist; don't conflate them:
+
+- **AI SDK tool approvals** (`toolApproval` on `generateText`/`streamText`) gate tools _you_ define in the AI SDK tool loop. Codex does not see these.
+- **Codex-native approvals** gate commands, file changes, skills, and MCP tool calls that Codex executes itself. Handle them with app-server `serverRequests` handlers, or set `autoApprove: true` to accept them by default. The stream surfaces them as `tool-approval-request` parts.
+
+## Streaming Behavior
+
+**`codexExec` mode:** incremental streaming is not currently available with `codex exec --experimental-json`. The format only emits `item.completed` events with full text, so `streamText()` works but delivers the text in a single chunk at the end.
+
+**`codexAppServer` mode:** supports true incremental deltas via `item/agentMessage/delta`, so `streamText()` emits progressively as tokens arrive.
+
+Consume the full event stream via `result.stream` (AI SDK v7 renamed `fullStream`):
+
+```js
+import { streamText } from 'ai';
+import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
+
+const provider = createCodexAppServer();
+const result = await streamText({
+  model: provider('gpt-5.5'),
+  prompt: 'List the files here, then summarize the largest one.',
+});
+
+for await (const part of result.stream) {
+  if (part.type === 'text-delta') process.stdout.write(part.text);
+  if (part.type === 'tool-call') console.log('\n🔧 tool:', part.toolName);
+  if (part.type === 'tool-result') console.log('✅ result received');
+}
+
+await provider.close();
+```
+
+Tool activity (`tool-input-start`, `tool-call`, `tool-result`, …) is emitted in real time in both modes, with `providerExecuted: true` because Codex runs its own tools autonomously.
+
+### Raw chunks (advanced)
+
+To see the raw Codex JSON-RPC notifications as `raw` stream parts, opt in with the v7 `include` option:
+
+```js
+const result = await streamText({
+  model: provider('gpt-5.5'),
+  prompt: 'Say hello.',
+  include: { rawChunks: true },
+});
+
+for await (const part of result.stream) {
+  if (part.type === 'raw') console.log(part.rawValue);
+}
+```
+
+`providerOptions['codex-app-server'].includeRawChunks: true` (or the same key in `defaultSettings`) is a provider-specific opt-in with the same effect.
+
+## App-Server Sessions (Stateful Threads)
+
+By default the app-server provider is stateless (a new ephemeral thread per call). Opt in to persistent threads to keep server-side context across calls:
+
+```js
+import { generateText } from 'ai';
+import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
+
+const provider = createCodexAppServer();
+
+const first = await generateText({
+  model: provider('gpt-5.5'),
+  prompt: 'Start a migration checklist.',
+  providerOptions: {
+    'codex-app-server': { threadMode: 'persistent' },
+  },
+});
+
+const threadId = first.finalStep.providerMetadata?.['codex-app-server']?.threadId;
+
+const second = await generateText({
+  model: provider('gpt-5.5'),
+  prompt: 'Continue from step 2.',
+  providerOptions: {
+    'codex-app-server': { threadId },
+  },
+});
+
+await provider.close();
+```
+
+Note the AI SDK v7 result shape: final-step metadata lives on `result.finalStep.providerMetadata` (for `streamText`, `await result.finalStep` first).
+
+Related settings: `threadMode`, `resume` (resume an existing thread id), `persistExtendedHistory`, and `onSessionCreated`, which hands you a live session object exposing `injectMessage()` and `interrupt()` for mid-turn control. See [configuration.md](./configuration.md#app-server-settings).
+
+## Logging Configuration
+
+Control how the provider logs execution information, warnings, and errors. Both provider modes accept the same `verbose` / `logger` settings.
+
+### Log Levels
+
+- **`debug`**: Detailed execution tracing (request/response, tool calls, stream events)
+- **`info`**: General execution flow information (session initialization, completion)
+- **`warn`**: Warnings about configuration issues or unexpected behavior
+- **`error`**: Error messages for failures and exceptions
+
+**Without verbose mode**, only `warn` and `error` messages are logged. **With `verbose: true`**, `debug` and `info` messages are also logged.
+
+### Basic Configuration
+
+```ts
+import { createCodexExec } from 'ai-sdk-provider-codex-cli';
+
+// Default: logs warnings and errors to console
+const defaultCodex = createCodexExec();
+
+// Disable all logging
+const silentCodex = createCodexExec({
+  defaultSettings: {
+    logger: false,
+  },
+});
+
+// Custom logger - must implement all four log levels
+const customCodex = createCodexExec({
+  defaultSettings: {
+    verbose: true,
+    logger: {
+      debug: (message) => myLogger.debug('Codex:', message),
+      info: (message) => myLogger.info('Codex:', message),
+      warn: (message) => myLogger.warn('Codex:', message),
+      error: (message) => myLogger.error('Codex:', message),
+    },
+  },
+});
+
+// Model-specific override
+const model = customCodex('gpt-5.5', {
+  logger: false, // Disable logging for this model only
+});
+```
+
+### Logger Options
+
+- `undefined` (default): Uses `console.debug`, `console.info`, `console.warn`, and `console.error` with `[DEBUG]`/`[INFO]`/`[WARN]`/`[ERROR]` tags
+- `false`: Disables all logging
+- Custom `Logger` object: Must implement `debug`, `info`, `warn`, and `error` methods
+
+### Combining with Error Handling
+
+```ts
+import { createCodexExec } from 'ai-sdk-provider-codex-cli';
+import { generateText } from 'ai';
+
+const codex = createCodexExec({
+  defaultSettings: { verbose: true },
+});
+
+try {
+  const result = await generateText({
+    model: codex('gpt-5.5'),
+    prompt: 'Hello!',
+  });
+  console.log(result.text);
+} catch (error) {
+  console.error('Generation failed:', error);
+  // Check error.data for additional context (exitCode, stderr, etc.)
+  if (error.data) {
+    console.error('Error details:', error.data);
+  }
+}
+```
+
+## Examples
+
+See [examples/](../../examples/) for runnable scripts (organized as `examples/exec/` and `examples/app-server/`) that cover:
+
+- Basic text generation and streaming
+- Conversation history and instructions
+- Permissions & sandbox modes
+- JSON object generation: basic, nested, constraints, advanced
+- Image inputs, raw chunks, model listing, local MCP tools, session injection
+
+## See Also
+
+- [configuration.md](./configuration.md) – every setting and its CLI/protocol mapping
+- [limitations.md](./limitations.md) – known constraints
+- [troubleshooting.md](./troubleshooting.md) – common issues and fixes
+- [migration-v6-to-v7.md](./migration-v6-to-v7.md) – upgrading from 1.x (AI SDK v6)

--- a/docs/ai-sdk-v7/limitations.md
+++ b/docs/ai-sdk-v7/limitations.md
@@ -1,0 +1,69 @@
+# Limitations
+
+## Runtime & Architecture
+
+- **Node.js >= 22 only** (AI SDK v7 baseline). The provider spawns a local process; Edge runtimes are not supported.
+- **ESM-only.** Version 2.x ships no CommonJS build; `require('ai-sdk-provider-codex-cli')` fails. Use `import` from ESM (`"type": "module"` or `.mjs`).
+- Model catalogs drift: model slugs are owned by Codex/OpenAI and change with the installed Codex CLI. Use `listModels()` / `provider.listModels()` instead of assuming a slug exists.
+
+## Prompt & File Inputs
+
+The provider implements the AI SDK v7 (spec v4) prompt shapes with these constraints:
+
+- **Images only.** `{ type: 'file' }` parts are supported when `mediaType` is `image/*` (or the top-level segment `'image'`). Non-image files produce an `unsupported` warning and are skipped.
+- **Tagged file data** (`data.type: 'data' | 'url' | 'text' | 'reference'`) is understood:
+  - `'data'` (bytes, base64, `data:` URLs) → written to a temp file and passed to Codex (`--image` for exec, `localImage` for app-server); temp files are cleaned up after each request.
+  - `'url'`: both providers declare `supportedUrls = {}`, so the AI SDK **downloads remote `https://` URLs itself** and delivers inline data to the provider — remote images therefore work end to end through the temp-file path. Raw HTTP URL shapes that reach the exec provider directly (bypassing SDK download) produce an `unsupported` warning; `file://` URLs are rejected with a warning in both modes.
+  - `'text'` and `'reference'` data are not supported for images (warning, skipped).
+- **`custom` parts** (assistant prompt or tool-result content) are not supported: the provider emits an `unsupported` warning and skips them.
+- **`reasoning-file` parts** are not supported: warning, skipped.
+- **Tool-result file content** uses the v7 canonical `{ type: 'file', mediaType, data: { ... } }` shape. Because Codex prompts are text transcripts, these are rendered as text markers (`[image-data: image/png]`, `[file-url: ...]`, `[file-id]`, or inline text for `data.type: 'text'`) rather than re-uploaded as binary inputs.
+
+## Streaming Behavior
+
+- **`codexExec`:** Codex `--experimental-json` mode emits events (`thread.started`, `turn.completed`, `item.completed`) rather than streaming text deltas; streaming returns the final text in a single chunk. The CLI provides the final assistant content in the `item.completed` event, which this provider reads and emits at the end.
+- **`codexAppServer`:** true incremental deltas via `item/agentMessage/delta`; `streamText()` emits progressively.
+
+## Tools & Tool Streaming
+
+- Codex executes its **own** tools (exec, patch, web_search, MCP tools) autonomously; tool calls/results stream in real time with `providerExecuted: true`, and runtime/provider tools are marked `dynamic: true`.
+- **AI SDK-defined tools are not forwarded to Codex.** Passing `tools` / `toolChoice` in a call produces `unsupported` warnings; Codex CLI has no way to call back into SDK tool implementations. Use Codex MCP servers (including `createSdkMcpServer()` in app-server mode) to expose your own capabilities instead.
+- Real-time tool _output_ streaming is limited: exec mode delivers tool output in the final `tool-result` event (`aggregatedOutput`); app-server mode surfaces output deltas only when Codex emits delta notifications.
+
+## JSON Schema
+
+- **Optional fields NOT supported**: OpenAI strict mode requires all fields to be required (no `.optional()`)
+- **Format validators stripped**: `.email()`, `.url()`, `.uuid()` are removed during sanitization (use descriptions instead)
+- **Pattern validators stripped**: `.regex()` is removed during sanitization (use descriptions instead)
+- See [LIMITATIONS.md](../../LIMITATIONS.md) at repo root for comprehensive details
+
+## AI SDK Parameter Support
+
+Some AI SDK parameters are not applicable to Codex CLI and are ignored with an `unsupported` warning: `temperature`, `topP`, `topK`, `maxOutputTokens`, `presencePenalty`, `frequencyPenalty`, `stopSequences`, `seed`, plus `tools` / `toolChoice` as described above.
+
+The top-level `reasoning` option **is** supported and maps to Codex reasoning effort; provider-specific options take precedence — see [configuration.md](./configuration.md#reasoning-precedence).
+
+## Model Parameter Validation
+
+**Known API quirks (exec mode):**
+
+### reasoningSummary Parameter
+
+The OpenAI Responses API has misleading error messages for the `reasoningSummary` parameter:
+
+- **Valid values:** `'auto'`, `'detailed'`
+- **Invalid values:** `'concise'`, `'none'` (rejected with 400 errors)
+
+**The quirk:** When you pass an invalid value like `'none'`, the API error claims valid values are `'concise', 'detailed', and 'auto'`. However, if you then try `'concise'`, the API rejects it as unsupported for the model.
+
+This provider's exec-mode types and validation only allow `'auto'` and `'detailed'` to prevent runtime errors. (The app-server protocol's `summary` setting accepts `'auto' | 'concise' | 'detailed' | 'none'`.)
+
+## Sessions
+
+- App-server persistent threads (`threadMode: 'persistent'`, `threadId`, `resume`) keep context server-side, but they are **not** a transcript store: there is no fork, resume-at-message, or checkpoint/rewind capability in the Codex app-server protocol.
+
+## Observability
+
+- Token usage is reported per call; with AI SDK v7, `result.usage` aggregates **all steps** (use `result.finalStep.usage` for final-step-only numbers).
+- Detailed fields live under `usage.inputTokenDetails` (e.g. `cacheReadTokens`) and `usage.outputTokenDetails` (e.g. `reasoningTokens`); the legacy top-level `cachedInputTokens` / `reasoningTokens` aliases were removed by AI SDK 7.
+- Codex-specific metadata (e.g. `threadId`) is exposed at `result.finalStep.providerMetadata['codex-app-server']` / `['codex-cli']`.

--- a/docs/ai-sdk-v7/migration-v6-to-v7.md
+++ b/docs/ai-sdk-v7/migration-v6-to-v7.md
@@ -14,7 +14,7 @@ Requirements that changed with 2.0.0:
 | ------------- | -------------------- | -------------------------------------------------- |
 | Node.js       | >= 18                | **>= 22**                                          |
 | Module format | ESM + CJS            | **ESM-only** (no `require()`)                      |
-| zod peer      | `^3.0.0 \|\| ^4.0.0` | `^3.25.76 \|\| ^4.1.8`                             |
+| zod peer      | `^3.0.0 \|\| ^4.0.0` | `^4.1.8` (Zod 4 only)                              |
 | Provider spec | LanguageModelV3      | **LanguageModelV4** (`specificationVersion: 'v4'`) |
 
 ## Staying on AI SDK v6
@@ -182,7 +182,7 @@ The app-server provider also exposes `provider.listModels()` over its existing p
 ## Checklist
 
 1. `node --version` ≥ 22; project runs as ESM.
-2. `npm i ai@^7 ai-sdk-provider-codex-cli@^2` (zod within `^3.25.76 || ^4.1.8`).
+2. `npm i ai@^7 ai-sdk-provider-codex-cli@^2` (zod `^4.1.8` required).
 3. Replace `require()` with `import`.
 4. Rename `system:` → `instructions:`; fix persisted chats containing `{ role: 'system' }`.
 5. Rename `result.fullStream` → `result.stream`; `includeRawChunks` → `include: { rawChunks: true }`.

--- a/docs/ai-sdk-v7/migration-v6-to-v7.md
+++ b/docs/ai-sdk-v7/migration-v6-to-v7.md
@@ -1,0 +1,193 @@
+# Migrating from 1.x (AI SDK v6) to 2.x (AI SDK v7)
+
+This guide is for users of `ai-sdk-provider-codex-cli` upgrading from the 1.x line (AI SDK v6) to 2.x (AI SDK v7). It covers the provider-specific changes plus the AI SDK 7 API renames most likely to touch code that uses this provider. For the exhaustive SDK-wide list, see the official [AI SDK 7 migration guide](https://ai-sdk.dev/docs/migration-guides/migration-guide-7-0).
+
+## Install
+
+```bash
+npm i ai@^7 ai-sdk-provider-codex-cli@^2
+```
+
+Requirements that changed with 2.0.0:
+
+| Requirement   | 1.x (AI SDK v6)      | 2.x (AI SDK v7)                                    |
+| ------------- | -------------------- | -------------------------------------------------- |
+| Node.js       | >= 18                | **>= 22**                                          |
+| Module format | ESM + CJS            | **ESM-only** (no `require()`)                      |
+| zod peer      | `^3.0.0 \|\| ^4.0.0` | `^3.25.76 \|\| ^4.1.8`                             |
+| Provider spec | LanguageModelV3      | **LanguageModelV4** (`specificationVersion: 'v4'`) |
+
+## Staying on AI SDK v6
+
+If you are not ready for Node 22 / ESM / AI SDK v7, pin the maintained 1.x line via its dist-tag:
+
+```bash
+npm i ai@^6 ai-sdk-provider-codex-cli@ai-sdk-v6
+```
+
+The `ai-sdk-v6` branch/tag receives maintenance fixes; `latest` now tracks the v7-compatible 2.x line.
+
+## ESM-Only Packaging
+
+AI SDK v7 packages are ESM-only, and so is this provider. The CJS build and the `require` export condition were removed.
+
+```js
+// ❌ no longer works
+const { codexExec } = require('ai-sdk-provider-codex-cli');
+
+// ✅ ESM import
+import { codexExec } from 'ai-sdk-provider-codex-cli';
+
+// ✅ from CommonJS, if you must
+const { codexAppServer } = await import('ai-sdk-provider-codex-cli');
+```
+
+Add `"type": "module"` to your `package.json` or use `.mjs` files.
+
+## AI SDK 7 API Renames You Will Hit
+
+These are AI SDK changes (not provider changes), but they affect nearly every snippet in our docs and examples:
+
+| AI SDK 6                                                            | AI SDK 7                                                                               | Notes                                                                                |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `system: '...'`                                                     | `instructions: '...'`                                                                  | `system` still works as a deprecated fallback                                        |
+| `result.fullStream`                                                 | `result.stream`                                                                        | `fullStream` is a deprecated alias                                                   |
+| `includeRawChunks: true`                                            | `include: { rawChunks: true }`                                                         | top-level option deprecated                                                          |
+| `result.providerMetadata` / `.request` / `.response` / `.reasoning` | `result.finalStep.*`                                                                   | top-level aliases deprecated; `await result.finalStep` for `streamText`              |
+| `result.totalUsage`                                                 | `result.usage`                                                                         | `usage` now aggregates all steps; `result.finalStep.usage` = old single-step `usage` |
+| `usage.cachedInputTokens` / `usage.reasoningTokens`                 | `usage.inputTokenDetails.cacheReadTokens` / `usage.outputTokenDetails.reasoningTokens` | old top-level fields removed                                                         |
+| `stepCountIs(n)`                                                    | `isStepCount(n)`                                                                       | tool-loop stop conditions                                                            |
+| `onFinish` / `onStepFinish`                                         | `onEnd` / `onStepEnd`                                                                  | old names are deprecated aliases                                                     |
+
+Example, before and after:
+
+```js
+// AI SDK 6 + provider 1.x
+const result = await streamText({
+  model,
+  system: 'Be terse.',
+  prompt: 'hi',
+  includeRawChunks: true,
+});
+for await (const part of result.fullStream) {
+  /* ... */
+}
+console.log(result.providerMetadata);
+```
+
+```js
+// AI SDK 7 + provider 2.x
+const result = await streamText({
+  model,
+  instructions: 'Be terse.',
+  prompt: 'hi',
+  include: { rawChunks: true },
+});
+for await (const part of result.stream) {
+  /* ... */
+}
+const finalStep = await result.finalStep;
+console.log(finalStep.providerMetadata);
+```
+
+## System Messages
+
+AI SDK 7 **rejects `{ role: 'system' }` messages inside `prompt`/`messages` by default**. This breaks persisted v6 chats and hand-built message arrays, independent of this provider:
+
+```js
+// ❌ throws in AI SDK 7
+await generateText({
+  model,
+  messages: [
+    { role: 'system', content: 'Be terse.' },
+    { role: 'user', content: 'hi' },
+  ],
+});
+
+// ✅ move system text to `instructions`
+await generateText({
+  model,
+  instructions: 'Be terse.',
+  messages: [{ role: 'user', content: 'hi' }],
+});
+```
+
+If you must keep existing histories that contain system messages (trusted, server-controlled content only), opt in with `allowSystemInMessages: true`.
+
+## Removed Legacy Model Properties
+
+The 1.x model instances carried v1/v2-era extension properties that AI SDK v7's `LanguageModelV4` interface no longer defines. They were removed in 2.0.0:
+
+- `defaultObjectGenerationMode`
+- `supportsStructuredOutputs`
+- `supportsImageUrls`
+
+If you introspected these on a model instance, delete that code — object generation and image support work through the standard v7 mechanisms (`responseFormat` and file parts). `supportedUrls` remains and is `{}` for both providers: the AI SDK downloads remote URLs and the provider handles the bytes via temp files.
+
+## Reasoning Option Mapping
+
+AI SDK 7 adds a top-level, provider-agnostic `reasoning` option. Provider 2.x maps it to Codex reasoning effort:
+
+```js
+await generateText({
+  model: codexExec('gpt-5.5', { allowNpx: true, skipGitRepoCheck: true }),
+  reasoning: 'high',
+  prompt: 'Think hard about this.',
+});
+```
+
+Precedence (highest first):
+
+1. `providerOptions['codex-cli'].reasoningEffort` (exec) / `providerOptions['codex-app-server'].effort` (app-server)
+2. top-level `reasoning` (when not `'provider-default'`)
+3. constructor settings (`reasoningEffort` / `effort`)
+4. Codex defaults
+
+When you adopt the top-level option, **remove overlapping reasoning entries from `providerOptions`** — if both are present, the provider-specific value silently wins. Full details in [configuration.md](./configuration.md#reasoning-precedence).
+
+## Message & Tool-Result File Shapes
+
+AI SDK 7 canonicalizes file inputs. Update message parts when convenient (deprecated shapes are auto-migrated by the SDK at runtime):
+
+```js
+// AI SDK 6 style (deprecated)
+{ type: 'image', image: imageBuffer, mimeType: 'image/png' }
+
+// AI SDK 7 canonical
+{ type: 'file', data: imageBuffer, mediaType: 'image/png' }
+```
+
+- `mediaType` accepts a full IANA type (`'image/png'`) or a top-level segment (`'image'`).
+- Tool-result content migrated from `image-*` / `file-*` variants to a single canonical `file` variant with tagged `data` (`{ type: 'data' | 'url' | 'reference' | 'text' }`); the provider consumes all of these.
+- New v7 part types the provider does **not** support — `custom` and `reasoning-file` — are skipped with an `unsupported` warning instead of failing the call.
+
+See [limitations.md](./limitations.md#prompt--file-inputs) for the full support matrix.
+
+## Model IDs
+
+2.x docs and examples no longer promise a model catalog: slugs are owned by Codex/OpenAI and drift with the installed CLI. Replace hard-coded lists with discovery:
+
+```js
+import { listModels } from 'ai-sdk-provider-codex-cli';
+
+const { models, defaultModel } = await listModels();
+console.log(
+  defaultModel?.id,
+  models.map((m) => m.id),
+);
+```
+
+The app-server provider also exposes `provider.listModels()` over its existing process.
+
+## Checklist
+
+1. `node --version` ≥ 22; project runs as ESM.
+2. `npm i ai@^7 ai-sdk-provider-codex-cli@^2` (zod within `^3.25.76 || ^4.1.8`).
+3. Replace `require()` with `import`.
+4. Rename `system:` → `instructions:`; fix persisted chats containing `{ role: 'system' }`.
+5. Rename `result.fullStream` → `result.stream`; `includeRawChunks` → `include: { rawChunks: true }`.
+6. Read final-step data from `result.finalStep.*`; usage detail fields from `usage.inputTokenDetails` / `usage.outputTokenDetails`.
+7. Delete any use of `defaultObjectGenerationMode`, `supportsStructuredOutputs`, `supportsImageUrls`.
+8. Prefer the top-level `reasoning` option; remove overlapping `providerOptions` reasoning keys.
+9. Replace hard-coded model lists with `listModels()`.
+10. Optionally run the official codemods: `npx @ai-sdk/codemod v7` (see the AI SDK migration guide).

--- a/docs/ai-sdk-v7/troubleshooting.md
+++ b/docs/ai-sdk-v7/troubleshooting.md
@@ -1,0 +1,92 @@
+# Troubleshooting
+
+## "codex not found" / CLI not on PATH
+
+- Install globally: `npm i -g @openai/codex`
+- Or enable fallback: `{ allowNpx: true }` (uses `npx -y @openai/codex`)
+- Or point at a specific binary: `{ codexPath: '/opt/homebrew/bin/codex' }`
+
+## Not authenticated / 401 / "Please login"
+
+- Run `codex login`
+- Ensure `~/.codex/auth.json` exists and is readable
+- Alternatively set `OPENAI_API_KEY` in `env`
+
+## `ERR_REQUIRE_ESM` / "require() of ES Module not supported"
+
+Version 2.x is ESM-only (as is AI SDK v7). `require('ai-sdk-provider-codex-cli')` cannot work.
+
+- Use `import` syntax and either add `"type": "module"` to your `package.json` or rename files to `.mjs`
+- From CommonJS you can use a dynamic import: `const { codexExec } = await import('ai-sdk-provider-codex-cli');`
+- If you cannot move to ESM/Node 22, stay on the v6-compatible 1.x line: `npm i ai@^6 ai-sdk-provider-codex-cli@ai-sdk-v6`
+
+## Syntax errors or engine warnings on startup
+
+- Node.js **22 or later** is required (`engines.node: ">=22"`); AI SDK v7 no longer supports Node 18/20. Check with `node --version`.
+
+## AI SDK error: system messages in `messages` rejected
+
+AI SDK 7 rejects `{ role: 'system' }` entries inside `prompt`/`messages` by default — this commonly surfaces with persisted v6 chat histories.
+
+- Preferred: move the system text to the top-level `instructions` option
+- For trusted, server-controlled histories only: pass `allowSystemInMessages: true`
+
+See [migration-v6-to-v7.md](./migration-v6-to-v7.md#system-messages) for examples.
+
+## Model not found / unexpected model errors
+
+Model slugs are owned by Codex/OpenAI and drift with the installed CLI. Don't guess:
+
+```js
+import { listModels } from 'ai-sdk-provider-codex-cli';
+const { models, defaultModel } = await listModels();
+console.log(
+  defaultModel?.id,
+  models.map((m) => m.id),
+);
+```
+
+Also check `codex --version`; upgrading the CLI (`npm i -g @openai/codex@latest`) changes the available models.
+
+## Sandbox / approval errors
+
+- Use safer defaults for non‑interactive runs:
+  - `approvalMode: 'on-failure'`
+  - `sandboxMode: 'workspace-write'`
+  - `skipGitRepoCheck: true` (exec)
+- For fully autonomous flows: `fullAuto: true` (be cautious). Avoid `dangerouslyBypassApprovalsAndSandbox` unless the environment is already sandboxed.
+- App-server: Codex-native approval requests (commands, file changes, skills, MCP elicitations) need a `serverRequests` handler or `autoApprove: true`; otherwise the provider answers with its default policy and your turn may be blocked from doing what you expected.
+
+## Streaming emits only a final chunk
+
+- `codexExec` mode: expected — `codex exec --experimental-json` emits completed-item events, not deltas. The provider still uses AI SDK's standard stream API.
+- For true incremental streaming, use `codexAppServer`.
+- Reading the full event stream? In AI SDK v7 it's `result.stream` (`fullStream` is a deprecated alias).
+
+## Process seems to hang after my script finishes
+
+The app-server provider keeps a shared `codex app-server` process alive between calls. Call `await provider.close()` (or `dispose()`) when done, or set `idleTimeoutMs` so the process exits after inactivity.
+
+## Remote image URLs
+
+- Pass remote images as `{ type: 'file', data: new URL('https://...'), mediaType: 'image/png' }` message parts. The provider declares `supportedUrls = {}`, so the AI SDK downloads the URL and the provider forwards the bytes via a temp file.
+- `file://` URLs are not supported (warning). Exec mode warns on raw HTTP URL shapes that bypass the SDK's download step.
+
+## Object generation fails with empty response
+
+The provider uses native `--output-schema` / `outputSchema` with OpenAI strict mode. Common issues:
+
+- **Optional fields**: Remove all `.optional()` calls - OpenAI strict mode requires all fields
+- **Format validators**: Remove `.email()`, `.url()`, `.uuid()` - use descriptions like "Valid email address" or "UUID format" instead
+- **Pattern validators**: Remove `.regex()` - use descriptions like "YYYY-MM-DD format" instead
+
+See [LIMITATIONS.md](../../LIMITATIONS.md) for full details.
+
+## My AI SDK tools never run
+
+Codex executes its own tools and cannot call back into AI SDK `tools` definitions; the provider warns and ignores `tools`/`toolChoice`. Expose custom capabilities as MCP servers instead (`mcpServers`, or `createSdkMcpServer()` in app-server mode). See [limitations.md](./limitations.md#tools--tool-streaming).
+
+## zod v3/v4 compatibility
+
+- The peer range is `zod@^3.25.76 || ^4.1.8` (matching AI SDK v7). If `npm i` reports an unmet peer, upgrade zod within that range.
+- NPM warnings from transitive peers do not affect functionality.

--- a/docs/ai-sdk-v7/troubleshooting.md
+++ b/docs/ai-sdk-v7/troubleshooting.md
@@ -86,7 +86,7 @@ See [LIMITATIONS.md](../../LIMITATIONS.md) for full details.
 
 Codex executes its own tools and cannot call back into AI SDK `tools` definitions; the provider warns and ignores `tools`/`toolChoice`. Expose custom capabilities as MCP servers instead (`mcpServers`, or `createSdkMcpServer()` in app-server mode). See [limitations.md](./limitations.md#tools--tool-streaming).
 
-## zod v3/v4 compatibility
+## zod v4 requirement
 
-- The peer range is `zod@^3.25.76 || ^4.1.8` (matching AI SDK v7). If `npm i` reports an unmet peer, upgrade zod within that range.
+- The peer range is `zod@^4.1.8` only. Zod 3 is not supported: importing under Zod 3 throws because `.refine().passthrough()` is unavailable on Zod 3's `ZodEffects`. Upgrade to Zod 4 if `npm i` reports an unmet peer.
 - NPM warnings from transitive peers do not affect functionality.

--- a/docs/ai-sdk-v7/upgrade-plan.md
+++ b/docs/ai-sdk-v7/upgrade-plan.md
@@ -2,6 +2,8 @@
 
 Date: 2026-07-06
 
+> Historical implementation plan. This document records the pre-migration state and decisions used to build the v7 branch; use the other `docs/ai-sdk-v7/*` guides for current user-facing guidance.
+
 This plan covers the `ai-sdk-provider-codex-cli` upgrade from the current AI SDK v6 line to an AI SDK v7-compatible release. It also records the branch/release strategy and agent-capability opportunities from AI SDK v7 and the Claude Agent SDK that are worth considering without overcommitting Codex-specific APIs that the Codex app-server protocol does not expose yet.
 
 ## Current repo and release state

--- a/docs/ai-sdk-v7/upgrade-plan.md
+++ b/docs/ai-sdk-v7/upgrade-plan.md
@@ -1,0 +1,510 @@
+# AI SDK v7 Compatibility Upgrade Plan
+
+Date: 2026-07-06
+
+This plan covers the `ai-sdk-provider-codex-cli` upgrade from the current AI SDK v6 line to an AI SDK v7-compatible release. It also records the branch/release strategy and agent-capability opportunities from AI SDK v7 and the Claude Agent SDK that are worth considering without overcommitting Codex-specific APIs that the Codex app-server protocol does not expose yet.
+
+## Current repo and release state
+
+- Active branch: `main` at `84f0e05780dd10c72403e27091678f011f0b5185`, tagged `v1.2.2`; working tree was clean during scouting.
+- Current package: `ai-sdk-provider-codex-cli@1.2.2`, described as an AI SDK v6 provider.
+- Current SDK dependency family:
+  - `@ai-sdk/provider`: `^3.0.0` (`3.0.10` in lockfile)
+  - `@ai-sdk/provider-utils`: `^4.0.1` (`4.0.27` in lockfile)
+  - `ai`: `^6.0.3` (`6.0.182` in lockfile)
+  - `@openai/codex`: optional `^0.130.0`
+  - `engines.node`: `>=18`
+- Existing compatibility lines:
+  - `main` / npm `latest`: AI SDK v6, package `1.x`, current `1.2.2`
+  - `origin/ai-sdk-v5` / npm `ai-sdk-v5`: AI SDK v5, package `0.7.3`
+  - `origin/ai-sdk-v4` / npm `ai-sdk-v4`: AI SDK v4, package `0.1.0-ai-sdk-v4`
+- Current docs structure is stale for the active branch: README is v6-oriented, but active docs still live under `docs/ai-sdk-v5/` and README links to those v5 docs.
+- Codex CLI drift:
+  - Repository optional dependency is still `@openai/codex@^0.130.0`.
+  - Global Codex available in the scout session was `0.142.5`.
+  - Live `app-server model/list` through the current provider returned default `gpt-5.5` and models `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex-spark`.
+  - The local optional `@openai/codex@0.130.0` install looked unhealthy for direct binary execution on this workstation, so v7 work should validate against an explicit Codex path or refreshed optional dependency rather than assuming the installed optional binary works.
+
+## Executive decisions
+
+1. **Release AI SDK v7 compatibility as `2.0.0`.** The AI SDK major/provider-interface change is a breaking contract, matching the prior v5-to-v6 `1.0.0` cutover.
+2. **Keep `main` as the active SDK-major line.** Cut an `ai-sdk-v6` maintenance branch from current `main`/`v1.2.2` before v7 lands.
+3. **Make v7 native, not merely v3-proxied.** AI SDK v7 can still accept `LanguageModelV3`, but its v3-to-v4 adapter only overrides `specificationVersion`; it does not down-convert v4 prompt/file shapes. Target native `LanguageModelV4` / `ProviderV4` for the stable v7 release.
+4. **Ship `2.0.0` ESM-only (decided).** AI SDK v7 packages are ESM-only and require Node 22+; `@ai-sdk/provider-utils@5` is an ESM-only *runtime* dependency. A retained CJS entry would rely on `require(esm)` — unflagged only from Node 22.12+ while `engines >=22` admits 22.0–22.11 — and would break if the dependency graph ever gains top-level await. Remove the `require` export and CJS build; document ESM-only support.
+5. **Do not hard-code a broad model catalog.** Use one current example model (`gpt-5.5` if still returned by `listModels()` during release verification) and document that model availability follows the installed Codex CLI. Keep `listModels()` / `provider.listModels()` prominent.
+6. **Treat Claude Agent SDK features as design references, not a direct API surface.** Add only features backed by Codex app-server protocol or AI SDK v7 public APIs. Defer Claude-specific fork/session-store/hooks/background-task/file-rewind APIs unless Codex exposes equivalent capabilities.
+
+## Branch, version, and publishing strategy
+
+### Branches
+
+- Before v7 implementation:
+  - Create `ai-sdk-v6` from `84f0e05` / `v1.2.2`.
+  - Push `ai-sdk-v6` to origin.
+  - Leave `origin/ai-sdk-v5` and `origin/ai-sdk-v4` unchanged.
+- During v7 implementation:
+  - Use a short-lived `ai-sdk-v7` feature branch if the work is not immediately releasable.
+  - Merge v7 to `main` for the stable `2.0.0` release.
+- After v7 stable:
+  - `main`: active v7 line.
+  - `ai-sdk-v6`: maintenance branch for v6 users.
+  - `ai-sdk-v5`: critical fixes only.
+  - `ai-sdk-v4`: frozen except severe install/security breakage.
+
+### npm dist-tags
+
+Before publishing stable v7:
+
+```bash
+npm dist-tag add ai-sdk-provider-codex-cli@1.2.2 ai-sdk-v6
+```
+
+For prereleases:
+
+```bash
+npm publish --tag next
+npm dist-tag add ai-sdk-provider-codex-cli@2.0.0-beta.N ai-sdk-v7
+```
+
+For stable:
+
+```bash
+npm publish --tag latest
+npm dist-tag add ai-sdk-provider-codex-cli@2.0.0 ai-sdk-v7
+```
+
+Preserve:
+
+- `ai-sdk-v5 -> 0.7.3`
+- `ai-sdk-v4 -> 0.1.0-ai-sdk-v4`
+
+After v7 is stable, every maintenance publish from an older SDK-major branch must publish with its SDK-major tag, not the npm default `latest` tag:
+
+```bash
+npm publish --tag ai-sdk-v6  # from the 1.x / ai-sdk-v6 branch
+npm publish --tag ai-sdk-v5  # from the 0.7.x / ai-sdk-v5 branch
+```
+
+This prevents a routine v6/v5 patch release from accidentally moving `latest` away from the v7 line.
+
+### Tags and release hygiene
+
+- Tag the stable release as `v2.0.0` on the exact package-version commit.
+- Tag prereleases as `v2.0.0-beta.N` only when `package.json` also has `2.0.0-beta.N`.
+- Avoid repeating existing tag/package mismatches observed during scouting:
+  - npm has `1.2.0`, but Git has no `v1.2.0` tag.
+  - npm has `0.1.0-ai-sdk-v4`, but Git has no matching `*ai-sdk-v4*` tag.
+  - Git tag `v1.0.0-beta.1` points at a commit whose package version was `0.7.0`.
+
+## Target dependency and runtime changes
+
+Update package metadata for v7:
+
+- `version`: `2.0.0` for stable release.
+- `description`: AI SDK v7 provider.
+- `engines.node`: `>=22`.
+- Runtime dependencies:
+  - `@ai-sdk/provider`: `^4.0.0`
+  - `@ai-sdk/provider-utils`: `^5.0.0`
+- Peer dependencies:
+  - raise `zod` from `^3.0.0 || ^4.0.0` to `^3.25.76 || ^4.1.8` to match the AI SDK v7 / `@ai-sdk/provider-utils@5` peer range.
+- Dev dependencies:
+  - `ai`: `^7.0.0`
+  - align `@types/node` with Node 22
+  - align TypeScript with the local AI SDK v7 workspace baseline if type friction appears.
+- Optional dependency:
+  - refresh `@openai/codex` from `^0.130.0` to a validated current line after release testing, likely `^0.142.5` if that remains current and app-server protocol tests pass.
+- Package format (decided: ESM-only):
+  - `tsup.config.ts`: `format: ['esm', 'cjs']` -> `['esm']`; remove the `require` condition from `exports`.
+  - Remove the top-level `main` field (currently `./dist/index.cjs`) and the legacy `module` field; `exports` with `types` + `import` is the only entrypoint.
+  - Rationale: `require(esm)` is unflagged only from Node 22.12+, and a CJS entry silently breaks if the transitive graph gains top-level await. Not a supportable contract for a major release.
+
+## Provider-interface migration plan
+
+### P0: native v4 provider cutover
+
+Update all exported and internal provider types from v3 to v4:
+
+- `LanguageModelV3` -> `LanguageModelV4`
+- `ProviderV3` -> `ProviderV4`
+- `SharedV3ProviderMetadata` / `SharedV3Warning` / `SharedV3ProviderOptions` -> v4 equivalents
+- `LanguageModelV3*` stream/content/tool/usage/finish types -> v4 equivalents
+- `specificationVersion: 'v3'` -> `specificationVersion: 'v4'`
+
+Primary files:
+
+- `src/exec-language-model.ts`
+- `src/exec-provider.ts`
+- `src/app-server/language-model.ts`
+- `src/app-server/provider.ts`
+- `src/app-server/stream/emitter.ts`
+- `src/app-server/stream/router.ts`
+- `src/app-server/stream/turn-stream-controller.ts`
+- `src/converters/types.ts`
+- `src/converters/prompt-converter.ts`
+- tests under `src/__tests__/`
+
+Keep provider-specific extension properties only if they still serve AI SDK v7 behavior:
+
+- `supportedUrls` remains required.
+- `defaultObjectGenerationMode`, `supportsStructuredOutputs`, and `supportsImageUrls` are legacy v1/v2-era extras absent from `LanguageModelV4`; remove them in `2.0.0`.
+
+### P0: v7 prompt, file, tool-result, and custom-part compatibility
+
+AI SDK v7 canonicalizes file/image inputs and tool-result content differently than the current converters expect.
+
+Implement converter support for v4 message file shapes:
+
+- `part.type === 'file'`
+- `part.data.type === 'data'` with `Uint8Array` or base64 string
+- `part.data.type === 'url'`
+- `part.data.type === 'reference'`
+- `part.data.type === 'text'`
+- top-level media type segments such as `mediaType: 'image'`, not only `image/*`
+
+Implement tool-result converter support for v7 canonical file content:
+
+- `output.type === 'content'` entries with `type: 'file'`
+- `data.type === 'data'`
+- `data.type === 'url'`
+- `data.type === 'reference'`
+- media/image markers should retain the fidelity currently provided by legacy v6 `file-data`, `file-url`, `file-id`, `image-data`, `image-url`, and `image-file-id` branches.
+
+Add explicit handling for v4 `custom` parts:
+
+- assistant prompt `type: 'custom'`
+- tool-result content `type: 'custom'`
+- generated/streamed `LanguageModelV4CustomContent`
+- policy: warn/skip unless the part is a Codex-owned stable custom kind that this provider intentionally supports.
+
+Provider behavior:
+
+- Exec provider:
+  - local/binary image data should still become temp files for `codex exec --image`.
+  - remote URLs remain unsupported unless Codex exec adds native remote-image support; emit explicit warnings.
+  - non-image files should produce warnings unless a real Codex input path exists.
+- App-server provider:
+  - decided for `2.0.0`: keep `supportedUrls = {}`. AI SDK v7 downloads remote URLs and delivers inline data, which flows through the existing tested temp-file/local-image path; no new Codex protocol dependency.
+  - URL passthrough (non-empty `supportedUrls`) is deferred until the Codex app-server verifiably accepts remote image URLs natively.
+  - binary images should continue through temp files as `{ type: 'localImage', path }`.
+  - non-image files should be warned or mapped only if Codex app-server adds file input support.
+
+Add explicit handling for v4 `reasoning-file` prompt/content parts:
+
+- If Codex cannot consume them, emit an unsupported warning instead of silently dropping them.
+- Add future output support only if Codex starts producing reasoning artifacts.
+
+### P0: top-level v7 reasoning option
+
+AI SDK v7 adds provider-agnostic call option:
+
+```ts
+reasoning?: 'provider-default' | 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+```
+
+Current provider behavior only honors provider-specific options:
+
+- exec: `providerOptions['codex-cli'].reasoningEffort`
+- app-server: `providerOptions['codex-app-server'].effort`
+
+Plan:
+
+- Map top-level `options.reasoning` to Codex effort when provider-specific reasoning/effort is absent.
+- Preserve provider-specific options as the higher-precedence override.
+- Document precedence.
+- Add tests for top-level reasoning, provider-specific override, and `provider-default` behavior.
+
+### P1: streams, tool calls, and approvals
+
+The existing emitted stream part names remain valid in AI SDK v7 v4:
+
+- `stream-start`
+- `response-metadata`
+- `text-start` / `text-delta` / `text-end`
+- `reasoning-start` / `reasoning-delta` / `reasoning-end`
+- `tool-input-start` / `tool-input-delta` / `tool-input-end`
+- `tool-call`
+- `tool-result`
+- `tool-approval-request`
+- `raw`
+- `finish`
+- `error`
+
+Required work:
+
+- Preserve `providerExecuted: true` for Codex-executed tools.
+- Preserve `dynamic: true` for runtime/provider tools such as Codex MCP tools.
+- Keep app-server approval requests typed and tested.
+- Add docs explaining the distinction between:
+  - AI SDK v7 SDK-tool approvals via `toolApproval`
+  - Codex-native command/file/skill/MCP approvals via provider `serverRequests` and app-server stream parts.
+
+Avoid overclaiming: Codex-native approvals are not automatically the same as SDK client-tool approvals.
+
+### P1: structured outputs
+
+Keep current JSON response-format path:
+
+- AI SDK v7 `generateObject` and `streamObject` still pass `responseFormat: { type: 'json', schema, name, description }` to the provider.
+- Exec provider should continue writing `--output-schema` after schema sanitization.
+- App-server provider should continue passing `outputSchema` and using JSON last-text-block behavior.
+
+Tests to add/update:
+
+- `generateObject` with required strict schema.
+- `streamObject` with incremental JSON output.
+- Optional-field limitation remains documented because OpenAI strict JSON schema still requires required fields.
+
+### P1: result and example migration
+
+Update user-facing docs/examples for AI SDK v7 API changes:
+
+- `result.fullStream` -> `result.stream`.
+- Prefer `instructions` over `system` in public examples.
+- `includeRawChunks` user-facing option -> `include: { rawChunks: true }`; keep provider-specific `providerOptions['codex-app-server'].includeRawChunks` only as a provider opt-in.
+- Prefer `result.finalStep.providerMetadata`, `result.finalStep.request`, and `result.finalStep.response` where examples need final-step data.
+- Update usage examples away from old aliases such as `cachedInputTokens` toward v7 usage detail fields.
+- Note in `migration-v6-to-v7.md`: AI SDK 7 rejects `{ role: 'system' }` messages inside `prompt`/`messages` by default; system text belongs in the top-level `instructions` option. This affects users with persisted v6 chats, independent of this provider.
+
+## Codex app-server and model plan
+
+### Codex version strategy
+
+- Refresh optional `@openai/codex` only after protocol tests pass against the target version.
+- Use `scripts/sync-protocol-types.sh` against the target Codex CLI to regenerate the app-server protocol reference.
+- Copy only needed protocol subsets into `src/app-server/protocol/types.ts` and update validators/tests.
+- Gate new app-server features with `minCodexVersion` and feature detection rather than assuming a newer CLI.
+
+### Model docs strategy
+
+- Use a single current default model in examples, likely `gpt-5.5` if release-time `listModels()` still returns it.
+- Mention the scout-observed model list only as an example of drift, not as a promised catalog.
+- Document:
+  - `listModels()` standalone helper.
+  - `provider.listModels()` on app-server provider.
+  - model slugs are owned by Codex/OpenAI and can change independently of this package.
+  - update concrete stale-model surfaces: `README.md` headline/catalog text and `package.json` keywords.
+
+## v7 and Claude Agent SDK capability opportunities
+
+### High-value for this package
+
+1. **AI SDK v7 ToolLoopAgent / WorkflowAgent examples**
+   - Add examples using `codexAppServer` as the backing model.
+   - Show `providerOptions['codex-app-server']` in agent flows.
+   - Show `prepareStep` adjusting provider options per step.
+   - Keep examples small and provider-centered.
+
+2. **Persistent Codex app-server sessions as the main agent feature**
+   - Promote `threadMode`, `threadId`, `resume`, `persistExtendedHistory`, and `onSessionCreated` in v7 docs.
+   - Document `injectMessage()` and `interrupt()` as live-control capabilities already supported by the provider.
+   - Avoid promising Claude-like fork/resume-at-message/session-store unless Codex exposes those protocol operations.
+
+3. **MCP lifecycle alignment**
+   - Align docs/types with AI SDK MCP v2 concepts: stdio, HTTP, SSE, SDK/in-process MCP servers, provider-owned vs request-scoped lifecycle.
+   - Keep existing lifecycle manager semantics: provider-owned servers persist; request-scoped servers are released on failure/finish.
+   - Consider dynamic MCP update/status APIs only if Codex app-server exposes reconnect/toggle/set/status protocol methods.
+
+4. **Approval and elicitation clarity**
+   - Keep `serverRequests` as the escape hatch for Codex-native command/file/skill/MCP elicitations.
+   - Document persist/remember semantics only when the Codex protocol semantics are exact and tested.
+   - Add tests for `mcpServer/elicitation/request` and dynamic tool approval handling because this is a core app-server value proposition.
+
+5. **Raw chunks as advanced opt-in**
+   - Keep raw JSON-RPC chunks opt-in.
+   - Do not map raw Codex app-server notifications into a fake stable standard event model.
+   - Test that raw chunks do not break AI SDK v7 workflow/UI stream transforms.
+
+### Medium-value, gated by protocol support
+
+- `setModel()` / mid-session model switching.
+- `mcpServerStatus()`, `reconnectMcpServer()`, `toggleMcpServer()`, `setMcpServers()`.
+- A Codex-backed sandbox adapter for AI SDK v7 `SandboxSession` if a real filesystem/process adapter exists.
+- Provider-tool definitions if Codex-native tools become representable through `LanguageModelV4ProviderTool`.
+
+### Defer for v7 core
+
+These Claude Agent SDK capabilities are useful references but should not be copied into this package without Codex protocol support:
+
+- session store / transcript portability
+- fork session / resume at message
+- general hook DSL
+- background tasks and subagent management
+- file checkpoint / rewind
+- broad Claude-style live control surface
+- full harness integration
+
+If pursued, harness integration should likely be a separate package or separate roadmap item, not part of the v7 provider compatibility release.
+
+## Documentation plan
+
+Add `docs/ai-sdk-v7/` with:
+
+- `guide.md`
+- `configuration.md`
+- `limitations.md`
+- `troubleshooting.md`
+- `migration-v6-to-v7.md`
+- this `upgrade-plan.md`
+
+Update README:
+
+- Badge/headline: AI SDK v7.
+- Compatibility table:
+
+| Package line | AI SDK | npm tag | Git branch | Status |
+| --- | --- | --- | --- | --- |
+| `2.x` | v7 | `latest`, `ai-sdk-v7` | `main` | active |
+| `1.x` | v6 | `ai-sdk-v6` | `ai-sdk-v6` | maintenance |
+| `0.7.x` | v5 | `ai-sdk-v5` | `ai-sdk-v5` | maintenance/critical fixes |
+| `0.1.0-ai-sdk-v4` | v4 | `ai-sdk-v4` | `ai-sdk-v4` | frozen |
+
+- Link active docs to `docs/ai-sdk-v7/*`.
+- Keep historical docs under their existing SDK-major folders.
+- Add v6 users' install command after stable v7:
+
+```bash
+npm i ai@^6 ai-sdk-provider-codex-cli@ai-sdk-v6
+```
+
+Update `CHANGELOG.md`:
+
+- Add `## [2.0.0] - YYYY-MM-DD`.
+- Include:
+  - AI SDK v7 compatibility.
+  - Node 22+ requirement.
+  - ESM-only packaging.
+  - Provider interface v4 migration.
+  - v7 prompt/file/reasoning compatibility.
+  - Codex CLI tested version and model-discovery note.
+  - v6 install path via `ai-sdk-v6` dist-tag.
+
+## Implementation phases
+
+### Phase 1: release-line setup
+
+- Cut and push `ai-sdk-v6` from current `main`/`v1.2.2`.
+- Add npm `ai-sdk-v6` dist-tag to `1.2.2`.
+- Create v7 work branch if not landing directly on `main`.
+- Record release/tag hygiene notes.
+
+### Phase 2: dependency and packaging cutover
+
+- Bump AI SDK dependencies to v7 family.
+- Raise Node engine to `>=22`.
+- Tighten the `zod` peer dependency to the AI SDK v7-compatible range.
+- Convert package exports/build to ESM-only: tsup `format: ['esm']`, drop the `require` export condition, remove stale `main`/`module` fields.
+- Refresh lockfile.
+- Run typecheck to reveal interface drift.
+
+### Phase 3: provider interface and converters
+
+- Rename provider/model/shared types to v4.
+- Set provider/model `specificationVersion` to `v4`.
+- Update prompt converters for v4 tagged file data.
+- Update tool-result converters for v7 canonical `type: 'file'` content entries.
+- Add top-level media type handling.
+- Add `custom` part warn/skip handling.
+- Add `reasoning-file` handling/warnings.
+- Map top-level `reasoning` to Codex effort with provider-specific override precedence.
+- Keep structured-output schema flow intact.
+
+### Phase 4: app-server protocol and Codex version
+
+- Validate target `@openai/codex` version.
+- Regenerate protocol reference with `scripts/sync-protocol-types.sh`.
+- Update protocol types/validators/tests only where the current provider consumes those shapes.
+- Re-check `listModels()` against explicit Codex path.
+- Update docs with tested Codex version and model-discovery guidance.
+
+### Phase 5: focused tests and examples
+
+- Update and add unit tests for v4 converter shapes.
+- Update provider-interface tests for v4 stream/content parts.
+- Add AI SDK v7 integration smoke tests around text, stream, object generation, raw chunks, image/file inputs, provider options, and app-server approvals.
+- Update examples for v7 public API changes.
+
+### Phase 6: docs, changelog, release verification
+
+- Add `docs/ai-sdk-v7/*`.
+- Update README compatibility table and active docs links.
+- Update `CHANGELOG.md`.
+- Build package.
+- Run targeted tests.
+- Run ESM import smoke.
+- Publish prerelease under `next`/`ai-sdk-v7`; promote to stable only after smoke coverage passes.
+
+## Targeted verification plan
+
+Run these after implementation, not as broad project-wide testing by default:
+
+```bash
+npm run typecheck
+```
+
+Focused converter tests:
+
+```bash
+npx vitest run \
+  src/__tests__/image-converter.test.ts \
+  src/__tests__/image-utils.test.ts \
+  src/__tests__/prompt-converter.test.ts \
+  src/__tests__/tool-result-converter.test.ts
+```
+
+Focused provider/app-server tests:
+
+```bash
+npx vitest run \
+  src/__tests__/exec-language-model.test.ts \
+  src/__tests__/app-server-language-model.test.ts \
+  src/__tests__/app-server-stream-emitter.test.ts \
+  src/__tests__/app-server-notification-router.test.ts \
+  src/__tests__/app-server-rpc-client.test.ts
+```
+
+AI SDK v7 smoke scenarios:
+
+- `generateText` text-only prompt.
+- `streamText` consuming `result.stream`.
+- `generateObject` strict schema.
+- `streamObject` JSON streaming.
+- app-server image prompt with v4 canonical `{ type: 'file', data: { type: 'data' } }`.
+- tool-result content with v7 canonical `{ type: 'file', data: { type: 'data' | 'url' | 'reference' } }`.
+- `custom` prompt/tool-result/generated content warns or maps only when intentionally supported.
+- remote image prompt behavior for exec and app-server.
+- app-server remote URL behavior with and without non-empty `supportedUrls`.
+- top-level `reasoning` and provider-specific override precedence.
+- raw chunk opt-in.
+- provider-executed dynamic tool result and tool approval request stream parts.
+- app-server `listModels()` against explicit current Codex path.
+
+Packaging smoke:
+
+```bash
+node -e "import('./dist/index.js').then(m => console.log(Object.keys(m).sort().join('\n')))"
+```
+
+## Main risks
+
+- **Runtime shape risk:** AI SDK v7 can proxy v3 models to v4, but it does not down-convert v4 prompt/file data. Converter hardening is mandatory even if v3 types temporarily compile.
+- **CJS risk (resolved: ESM-only):** `require(esm)` is unflagged only from Node 22.12+ and breaks if the dependency graph gains top-level await, so a CJS entry cannot be reliably supported under `engines.node >=22`.
+- **Node support risk:** v7 requires Node 22+, while current package supports Node 18+.
+- **Codex binary risk:** installed optional Codex package and global Codex can diverge. Release verification must use explicit paths and versions.
+- **Model drift risk:** Codex model slugs changed between docs and live app-server output. Prefer discovery over static catalogs.
+- **Approval security risk:** persisted approval semantics are security-sensitive. Do not expose “remember” APIs without exact Codex protocol semantics and tests.
+- **Session durability risk:** Codex app-server thread IDs are not automatically Claude-style session stores or file checkpoints. Do not promise transcript portability, fork, or rewind.
+- **MCP lifecycle risk:** dynamic MCP changes can leak processes or stale credentials if provider-owned/request-owned lifecycle is not preserved.
+
+## Acceptance criteria for v7 release
+
+- `package.json` and lockfile use AI SDK v7 dependency family, Node 22+, and the tightened v7-compatible `zod` peer range.
+- Public provider exports compile as AI SDK v7-compatible native v4 models/providers.
+- Exec and app-server prompt converters handle v7 file/image prompt shapes, canonical tool-result file content, `custom` parts, and `reasoning-file` parts or emit explicit unsupported warnings.
+- Top-level v7 `reasoning` is mapped or explicitly documented with tested precedence.
+- Structured object generation still works for exec and app-server paths.
+- App-server streams preserve text, reasoning, raw, dynamic/provider-executed tool, and approval parts.
+- `listModels()` works against the release-tested Codex CLI and docs avoid stale model catalogs.
+- README compatibility table includes v7/v6/v5/v4 lines and active docs point to `docs/ai-sdk-v7/`.
+- Changelog documents breaking changes and install path for v6 users.
+- Targeted tests and packaging smokes pass.

--- a/docs/ai-sdk-v7/upgrade-plan.md
+++ b/docs/ai-sdk-v7/upgrade-plan.md
@@ -30,7 +30,7 @@ This plan covers the `ai-sdk-provider-codex-cli` upgrade from the current AI SDK
 1. **Release AI SDK v7 compatibility as `2.0.0`.** The AI SDK major/provider-interface change is a breaking contract, matching the prior v5-to-v6 `1.0.0` cutover.
 2. **Keep `main` as the active SDK-major line.** Cut an `ai-sdk-v6` maintenance branch from current `main`/`v1.2.2` before v7 lands.
 3. **Make v7 native, not merely v3-proxied.** AI SDK v7 can still accept `LanguageModelV3`, but its v3-to-v4 adapter only overrides `specificationVersion`; it does not down-convert v4 prompt/file shapes. Target native `LanguageModelV4` / `ProviderV4` for the stable v7 release.
-4. **Ship `2.0.0` ESM-only (decided).** AI SDK v7 packages are ESM-only and require Node 22+; `@ai-sdk/provider-utils@5` is an ESM-only *runtime* dependency. A retained CJS entry would rely on `require(esm)` — unflagged only from Node 22.12+ while `engines >=22` admits 22.0–22.11 — and would break if the dependency graph ever gains top-level await. Remove the `require` export and CJS build; document ESM-only support.
+4. **Ship `2.0.0` ESM-only (decided).** AI SDK v7 packages are ESM-only and require Node 22+; `@ai-sdk/provider-utils@5` is an ESM-only _runtime_ dependency. A retained CJS entry would rely on `require(esm)` — unflagged only from Node 22.12+ while `engines >=22` admits 22.0–22.11 — and would break if the dependency graph ever gains top-level await. Remove the `require` export and CJS build; document ESM-only support.
 5. **Do not hard-code a broad model catalog.** Use one current example model (`gpt-5.5` if still returned by `listModels()` during release verification) and document that model availability follows the installed Codex CLI. Keep `listModels()` / `provider.listModels()` prominent.
 6. **Treat Claude Agent SDK features as design references, not a direct API surface.** Add only features backed by Codex app-server protocol or AI SDK v7 public APIs. Defer Claude-specific fork/session-store/hooks/background-task/file-rewind APIs unless Codex exposes equivalent capabilities.
 
@@ -352,12 +352,12 @@ Update README:
 - Badge/headline: AI SDK v7.
 - Compatibility table:
 
-| Package line | AI SDK | npm tag | Git branch | Status |
-| --- | --- | --- | --- | --- |
-| `2.x` | v7 | `latest`, `ai-sdk-v7` | `main` | active |
-| `1.x` | v6 | `ai-sdk-v6` | `ai-sdk-v6` | maintenance |
-| `0.7.x` | v5 | `ai-sdk-v5` | `ai-sdk-v5` | maintenance/critical fixes |
-| `0.1.0-ai-sdk-v4` | v4 | `ai-sdk-v4` | `ai-sdk-v4` | frozen |
+| Package line      | AI SDK | npm tag               | Git branch  | Status                     |
+| ----------------- | ------ | --------------------- | ----------- | -------------------------- |
+| `2.x`             | v7     | `latest`, `ai-sdk-v7` | `main`      | active                     |
+| `1.x`             | v6     | `ai-sdk-v6`           | `ai-sdk-v6` | maintenance                |
+| `0.7.x`           | v5     | `ai-sdk-v5`           | `ai-sdk-v5` | maintenance/critical fixes |
+| `0.1.0-ai-sdk-v4` | v4     | `ai-sdk-v4`           | `ai-sdk-v4` | frozen                     |
 
 - Link active docs to `docs/ai-sdk-v7/*`.
 - Keep historical docs under their existing SDK-major folders.

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ Provider-specific notes:
   - `npm i -g @openai/codex`
   - `codex login` (or set `OPENAI_API_KEY`)
 - Build this package before running examples: `npm run build`
-- App-server examples require Codex CLI `>= 0.130.0`.
+- App-server examples require Codex CLI `>= 0.142.5`.
 
 ## Run
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -78,7 +78,7 @@ These demonstrate features that only exist in `codex app-server` mode:
 - `examples/app-server/session-injection.mjs` - uses `onSessionCreated` + `session.injectMessage()`
 - `examples/app-server/local-mcp-tool.mjs` - registers in-process tools with `createSdkMcpServer()` (loopback-bound + bearer-auth local MCP transport)
 - `examples/app-server/abort.mjs` - demonstrates aborting an in-flight stream with `AbortController`
-- `examples/app-server/raw-chunks.mjs` - enables `includeRawChunks` and inspects raw protocol events
+- `examples/app-server/raw-chunks.mjs` - enables `include: { rawChunks: true }` and inspects raw protocol events
 - `examples/app-server/usage-metadata.mjs` - prints token usage and provider metadata from a generation
 
 ## Troubleshooting

--- a/examples/app-server/README.md
+++ b/examples/app-server/README.md
@@ -7,7 +7,7 @@ These examples use `createCodexAppServer` and a persistent `codex app-server` JS
 - Best for higher-throughput or stateful workflows.
 - Stateful continuation starts from a persistent thread and then uses `providerOptions['codex-app-server'].threadId`.
 - Server-initiated JSON-RPC requests can be handled with `serverRequests`.
-- Requires Codex CLI `>= 0.130.0`.
+- Requires Codex CLI `>= 0.142.5`.
 
 ## Thread Lifecycle
 

--- a/examples/app-server/abort.mjs
+++ b/examples/app-server/abort.mjs
@@ -2,7 +2,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/advanced-settings.mjs
+++ b/examples/app-server/advanced-settings.mjs
@@ -2,7 +2,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/basic-usage.mjs
+++ b/examples/app-server/basic-usage.mjs
@@ -2,7 +2,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/check-cli.mjs
+++ b/examples/app-server/check-cli.mjs
@@ -41,7 +41,7 @@ console.log('  app-server command available');
 console.log('\n Running minimal app-server generation...');
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.130.0',
+    minCodexVersion: '0.142.5',
     idleTimeoutMs: 30000,
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },

--- a/examples/app-server/cmdline-limit-test.mjs
+++ b/examples/app-server/cmdline-limit-test.mjs
@@ -29,7 +29,7 @@ async function main() {
 
   const codex = createCodexAppServer({
     defaultSettings: {
-      minCodexVersion: '0.130.0',
+      minCodexVersion: '0.142.5',
       idleTimeoutMs: 30000,
       cwd: process.cwd(),
       approvalPolicy: 'on-failure',

--- a/examples/app-server/conversation-history.mjs
+++ b/examples/app-server/conversation-history.mjs
@@ -10,7 +10,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/conversation-history.mjs
+++ b/examples/app-server/conversation-history.mjs
@@ -26,7 +26,7 @@ try {
   });
   console.log('Turn 1:', first.text);
 
-  const threadId = first.providerMetadata?.['codex-app-server']?.threadId;
+  const threadId = first.finalStep.providerMetadata?.['codex-app-server']?.threadId;
   if (!threadId) {
     throw new Error('No threadId returned from app-server provider.');
   }

--- a/examples/app-server/custom-config.mjs
+++ b/examples/app-server/custom-config.mjs
@@ -2,7 +2,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/custom-config.mjs
+++ b/examples/app-server/custom-config.mjs
@@ -1,21 +1,28 @@
 import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
-const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
-});
+const defaultSettings = {
+  minCodexVersion: '0.142.5',
+  idleTimeoutMs: 30000,
+};
+
+const appServer = createCodexAppServer({ defaultSettings });
 
 try {
-  // Demonstrates custom CWD plus approval/sandbox policy options
-
-  const model = appServer('gpt-5.5', {
+  // Demonstrates custom CWD plus approval/sandbox policy options.
+  const modelSettings = {
     cwd: process.cwd(),
     // Optional app-server style policy overrides:
     // approvalPolicy: 'on-request',
     // personality: 'pragmatic',
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },
-  });
+  };
+
+  console.log('Default app-server settings:', JSON.stringify(defaultSettings));
+  console.log('Per-model settings:', JSON.stringify(modelSettings));
+
+  const model = appServer('gpt-5.5', modelSettings);
 
   const { text } = await generateText({
     model,

--- a/examples/app-server/error-handling.mjs
+++ b/examples/app-server/error-handling.mjs
@@ -4,7 +4,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer, isAuthenticationError } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/experimental-json-events.mjs
+++ b/examples/app-server/experimental-json-events.mjs
@@ -15,7 +15,7 @@ import { generateText, streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 function getUsageTotals(usage) {

--- a/examples/app-server/experimental-json-events.mjs
+++ b/examples/app-server/experimental-json-events.mjs
@@ -19,15 +19,10 @@ const appServer = createCodexAppServer({
 });
 
 function getUsageTotals(usage) {
-  const inputTokens =
-    typeof usage.inputTokens === 'number' ? usage.inputTokens : (usage.inputTokens?.total ?? 0);
-  const outputTokens =
-    typeof usage.outputTokens === 'number' ? usage.outputTokens : (usage.outputTokens?.total ?? 0);
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
   const totalTokens = usage.totalTokens ?? inputTokens + outputTokens;
-  const cacheRead =
-    usage.cachedInputTokens ??
-    usage.inputTokenDetails?.cacheReadTokens ??
-    usage.inputTokens?.cacheRead;
+  const cacheRead = usage.inputTokenDetails?.cacheReadTokens;
 
   return { inputTokens, outputTokens, totalTokens, cacheRead };
 }
@@ -43,10 +38,11 @@ try {
   async function example1_basicWithUsage() {
     console.log('1  Basic Generation with Usage Tracking\n');
 
-    const { text, usage, response } = await generateText({
+    const { text, usage, finalStep } = await generateText({
       model,
       prompt: 'Explain the concept of native JSON schema support in 2 sentences.',
     });
+    const response = finalStep.response;
 
     console.log(' Response:');
     console.log(text);

--- a/examples/app-server/generate-object-advanced.mjs
+++ b/examples/app-server/generate-object-advanced.mjs
@@ -12,14 +12,14 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {
   console.log(' Codex CLI - Advanced Object Generation\n');
 
   // Use the Codex flagship model to exercise extra-high reasoning effort.
-  // Requires the validated Codex CLI 0.130.x line for gpt-5.5 + xhigh.
+  // Requires the validated Codex CLI 0.142.x line for gpt-5.5 + xhigh.
   const model = appServer('gpt-5.5', {
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },

--- a/examples/app-server/generate-object-basic.mjs
+++ b/examples/app-server/generate-object-basic.mjs
@@ -13,7 +13,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/generate-object-constraints.mjs
+++ b/examples/app-server/generate-object-constraints.mjs
@@ -11,7 +11,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/generate-object-native-schema.mjs
+++ b/examples/app-server/generate-object-native-schema.mjs
@@ -15,7 +15,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/generate-object-nested.mjs
+++ b/examples/app-server/generate-object-nested.mjs
@@ -12,7 +12,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/image-support.mjs
+++ b/examples/app-server/image-support.mjs
@@ -24,7 +24,7 @@ import { generateText, streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/limitations.mjs
+++ b/examples/app-server/limitations.mjs
@@ -4,7 +4,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/list-models.mjs
+++ b/examples/app-server/list-models.mjs
@@ -3,7 +3,7 @@
 import { listModels } from 'ai-sdk-provider-codex-cli';
 
 const { models, defaultModel } = await listModels({
-  minCodexVersion: '0.130.0',
+  minCodexVersion: '0.142.5',
 });
 
 console.log(`Found ${models.length} model(s).`);

--- a/examples/app-server/local-mcp-tool.mjs
+++ b/examples/app-server/local-mcp-tool.mjs
@@ -18,7 +18,7 @@ const mathServer = createSdkMcpServer({
 
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.130.0',
+    minCodexVersion: '0.142.5',
     idleTimeoutMs: 30000,
     mcpServers: {
       math: mathServer,

--- a/examples/app-server/logging-custom-logger.mjs
+++ b/examples/app-server/logging-custom-logger.mjs
@@ -20,7 +20,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/logging-default.mjs
+++ b/examples/app-server/logging-default.mjs
@@ -18,7 +18,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/logging-disabled.mjs
+++ b/examples/app-server/logging-disabled.mjs
@@ -27,7 +27,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/logging-verbose.mjs
+++ b/examples/app-server/logging-verbose.mjs
@@ -24,7 +24,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/long-prompt-test.mjs
+++ b/examples/app-server/long-prompt-test.mjs
@@ -85,7 +85,7 @@ async function main() {
 
   const codex = createCodexAppServer({
     defaultSettings: {
-      minCodexVersion: '0.130.0',
+      minCodexVersion: '0.142.5',
       idleTimeoutMs: 30000,
       cwd: process.cwd(),
       approvalPolicy: 'on-failure',

--- a/examples/app-server/long-prompt-test.mjs
+++ b/examples/app-server/long-prompt-test.mjs
@@ -99,7 +99,7 @@ async function main() {
 
     const result = await generateText({
       model: codex('gpt-5.5'),
-      system: FRONTEND_PROMPT,
+      instructions: FRONTEND_PROMPT,
       prompt: USER_PROMPT,
     });
 

--- a/examples/app-server/long-running-tasks.mjs
+++ b/examples/app-server/long-running-tasks.mjs
@@ -8,7 +8,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/permissions-and-sandbox.mjs
+++ b/examples/app-server/permissions-and-sandbox.mjs
@@ -11,7 +11,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/provider-options.mjs
+++ b/examples/app-server/provider-options.mjs
@@ -12,6 +12,7 @@ try {
     });
 
     console.log('=== Quick Response (Low Effort) ===');
+    console.log('Per-call option:', JSON.stringify({ effort: 'low' }));
     const quick = await generateText({
       model,
       prompt: 'Summarize JSON schema validation in one short sentence.',
@@ -24,41 +25,46 @@ try {
     console.log(quick.text);
 
     console.log('\n=== Deep Analysis (High Effort) ===');
+    console.log('Per-call option:', JSON.stringify({ effort: 'high' }));
     const deep = await generateText({
       model,
       prompt: 'Compare event-driven and batch ETL in exactly 2 concise bullets.',
       providerOptions: {
         'codex-app-server': {
-          effort: 'medium',
+          effort: 'high',
         },
       },
     });
     console.log(deep.text);
 
     console.log('\n=== Custom Config Overrides per Call ===');
+    const configOverrides = {
+      experimental_resume: 'provider-options.jsonl',
+      'sandbox_workspace_write.network_access': true,
+    };
+    console.log('Per-call option:', JSON.stringify({ configOverrides }));
     const tuned = await generateText({
       model,
       prompt: 'Reply with exactly: Config overrides applied.',
       providerOptions: {
         'codex-app-server': {
-          configOverrides: {
-            experimental_resume: 'provider-options.jsonl',
-            'sandbox_workspace_write.network_access': true,
-          },
+          configOverrides,
         },
       },
     });
     console.log(tuned.text);
 
     console.log('\n=== Per-call Sandbox Override ===');
+    const sandboxOverride = {
+      approvalPolicy: 'never',
+      sandboxPolicy: { type: 'readOnly' },
+    };
+    console.log('Per-call option:', JSON.stringify(sandboxOverride));
     const sandboxed = await generateText({
       model,
       prompt: 'Reply with exactly: Sandbox override configured.',
       providerOptions: {
-        'codex-app-server': {
-          approvalPolicy: 'never',
-          sandboxPolicy: { type: 'readOnly' },
-        },
+        'codex-app-server': sandboxOverride,
       },
     });
     console.log(sandboxed.text);

--- a/examples/app-server/provider-options.mjs
+++ b/examples/app-server/provider-options.mjs
@@ -2,7 +2,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/raw-chunks.mjs
+++ b/examples/app-server/raw-chunks.mjs
@@ -14,14 +14,14 @@ try {
 
   const result = streamText({
     model,
-    includeRawChunks: true,
+    include: { rawChunks: true },
     prompt: 'Give a short two-sentence summary of why tests matter.',
   });
 
   let text = '';
   let rawChunkCount = 0;
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     if (part.type === 'text-delta') {
       text += part.text ?? part.delta ?? '';
     }

--- a/examples/app-server/raw-chunks.mjs
+++ b/examples/app-server/raw-chunks.mjs
@@ -2,7 +2,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/session-injection.mjs
+++ b/examples/app-server/session-injection.mjs
@@ -5,7 +5,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.130.0',
+    minCodexVersion: '0.142.5',
     idleTimeoutMs: 30000,
     threadMode: 'persistent',
     effort: 'medium',

--- a/examples/app-server/session-injection.mjs
+++ b/examples/app-server/session-injection.mjs
@@ -17,14 +17,14 @@ try {
   const result = streamText({
     model: provider('gpt-5.5'),
     prompt:
-      'Write a tiny Node.js function named parseCsvLine that parses one CSV line with no dependencies. Return one markdown code block only. Do not include explanations, usage examples, commands, or file writes.',
+      'Write a tiny Node.js function named parseCsvLine that parses one CSV line with no dependencies. Start with one markdown code block. If you receive follow-up guidance while writing, append a second revised markdown code block rather than trying to erase earlier streamed text.',
     providerOptions: {
       'codex-app-server': {
         onSessionCreated: (session) => {
           // Demonstrates mid-execution guidance while the turn is in-flight.
           setTimeout(() => {
             void session.injectMessage(
-              'Update the code block to include basic input validation only. Keep exactly one markdown code block and no explanatory text.',
+              'Append a second revised markdown code block that includes basic input validation. Prefix it with "Revised version:" and do not erase the original streamed block.',
             );
           }, 500);
         },

--- a/examples/app-server/streaming-multiple-tools.mjs
+++ b/examples/app-server/streaming-multiple-tools.mjs
@@ -39,8 +39,9 @@ try {
 
     const toolCalls = [];
     const textParts = [];
+    let threadId;
 
-    for await (const part of result.fullStream) {
+    for await (const part of result.stream) {
       switch (part.type) {
         case 'response-metadata':
           break;
@@ -110,6 +111,11 @@ try {
           break;
         }
 
+        case 'finish-step': {
+          threadId = part.providerMetadata?.['codex-app-server']?.threadId ?? threadId;
+          break;
+        }
+
         case 'finish': {
           // Display final text response
           if (textParts.length > 0) {
@@ -119,11 +125,10 @@ try {
             console.log(''.repeat(60));
           }
 
-          // Usage stats - AI SDK v6 stable uses nested structure
-          const usage = part.totalUsage || part.usage;
-          const inputTotal = usage?.inputTokens?.total ?? 0;
-          const outputTotal = usage?.outputTokens?.total ?? 0;
-          const threadId = part.providerMetadata?.['codex-app-server']?.threadId;
+          // Usage stats - AI SDK v7 uses flat token totals
+          const usage = part.totalUsage;
+          const inputTotal = usage?.inputTokens ?? 0;
+          const outputTotal = usage?.outputTokens ?? 0;
           if (threadId) {
             console.log(`\n Thread: ${threadId}`);
           }

--- a/examples/app-server/streaming-multiple-tools.mjs
+++ b/examples/app-server/streaming-multiple-tools.mjs
@@ -69,10 +69,13 @@ try {
         }
 
         case 'tool-result': {
-          const output =
-            part.result && typeof part.result === 'object' && part.result.type === 'tool-result'
-              ? part.result.output
-              : part.result;
+          // Preliminary output-delta parts can arrive before the final tool result;
+          // skip them so summary/completion counting stays correct.
+          if (part.preliminary === true) {
+            break;
+          }
+
+          const output = part.output;
           const tool = toolCalls.find((t) => t.id === part.toolCallId);
 
           if (tool) {

--- a/examples/app-server/streaming-multiple-tools.mjs
+++ b/examples/app-server/streaming-multiple-tools.mjs
@@ -7,7 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const appServer = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.130.0',
+    minCodexVersion: '0.142.5',
     idleTimeoutMs: 30000,
     cwd: __dirname,
   },

--- a/examples/app-server/streaming-tool-calls.mjs
+++ b/examples/app-server/streaming-tool-calls.mjs
@@ -30,8 +30,9 @@ try {
     });
 
     const textBuffer = [];
+    let threadId;
 
-    for await (const part of result.fullStream) {
+    for await (const part of result.stream) {
       switch (part.type) {
         case 'response-metadata':
           break;
@@ -77,7 +78,7 @@ try {
           break;
         }
         case 'text-delta': {
-          // AI SDK fullStream uses .text for text-delta events
+          // AI SDK stream uses .text for text-delta events
           const textDelta = part.text ?? part.delta;
           if (typeof textDelta === 'string') {
             textBuffer.push(textDelta);
@@ -85,12 +86,15 @@ try {
           }
           break;
         }
+        case 'finish-step': {
+          threadId = part.providerMetadata?.['codex-app-server']?.threadId ?? threadId;
+          break;
+        }
         case 'finish': {
-          // AI SDK v6 stable uses nested usage structure with inputTokens.total, outputTokens.total
-          const usage = part.totalUsage || part.usage;
-          const inputTotal = usage?.inputTokens?.total ?? 0;
-          const outputTotal = usage?.outputTokens?.total ?? 0;
-          const threadId = part.providerMetadata?.['codex-app-server']?.threadId;
+          // AI SDK v7 usage exposes flat token totals
+          const usage = part.totalUsage;
+          const inputTotal = usage?.inputTokens ?? 0;
+          const outputTotal = usage?.outputTokens ?? 0;
           if (threadId) {
             console.log(`\n Thread: ${threadId}`);
           }

--- a/examples/app-server/streaming-tool-calls.mjs
+++ b/examples/app-server/streaming-tool-calls.mjs
@@ -58,17 +58,16 @@ try {
           console.log(` Executing tool: ${part.toolName} (${part.toolCallId})`);
           break;
         case 'tool-result': {
-          const result = part.result;
+          const output = part.output;
 
-          if (result && typeof result === 'object' && result.type === 'output-delta') {
-            const streamLabel = result.stream ?? 'stdout';
-            if (typeof result.output === 'string' && result.output.length > 0) {
-              console.log(` ${streamLabel}:\n${result.output}`);
+          if (output && typeof output === 'object' && output.type === 'output-delta') {
+            if (typeof output.delta === 'string' && output.delta.length > 0) {
+              console.log(` stdout:\n${output.delta}`);
             }
             break;
           }
 
-          const payload = result ?? part.providerMetadata?.['codex-app-server'];
+          const payload = output ?? part.providerMetadata?.['codex-app-server'];
           if (payload) {
             console.log(` Tool result (${part.toolCallId}):\n${JSON.stringify(payload, null, 2)}`);
           } else {

--- a/examples/app-server/streaming-tool-calls.mjs
+++ b/examples/app-server/streaming-tool-calls.mjs
@@ -2,7 +2,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/streaming.mjs
+++ b/examples/app-server/streaming.mjs
@@ -2,7 +2,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/system-messages.mjs
+++ b/examples/app-server/system-messages.mjs
@@ -15,7 +15,7 @@ try {
 
   const { text } = await generateText({
     model,
-    system: 'You are a terse assistant. Always reply in exactly 3 words.',
+    instructions: 'You are a terse assistant. Always reply in exactly 3 words.',
     prompt: 'Describe TypeScript in a nutshell.',
   });
   console.log('System-influenced reply:', text);

--- a/examples/app-server/system-messages.mjs
+++ b/examples/app-server/system-messages.mjs
@@ -4,7 +4,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/usage-metadata.mjs
+++ b/examples/app-server/usage-metadata.mjs
@@ -23,7 +23,7 @@ try {
     totalTokens: result.usage?.totalTokens ?? 0,
   });
 
-  const metadata = result.providerMetadata?.['codex-app-server'] ?? {};
+  const metadata = result.finalStep.providerMetadata?.['codex-app-server'] ?? {};
   console.log('Provider metadata keys:', Object.keys(metadata));
   console.log('Usage metadata example complete.');
 } finally {

--- a/examples/app-server/usage-metadata.mjs
+++ b/examples/app-server/usage-metadata.mjs
@@ -2,7 +2,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.130.0', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/exec/experimental-json-events.mjs
+++ b/examples/exec/experimental-json-events.mjs
@@ -26,15 +26,10 @@ const model = codexExec('gpt-5.5', {
 });
 
 function getUsageTotals(usage) {
-  const inputTokens =
-    typeof usage.inputTokens === 'number' ? usage.inputTokens : (usage.inputTokens?.total ?? 0);
-  const outputTokens =
-    typeof usage.outputTokens === 'number' ? usage.outputTokens : (usage.outputTokens?.total ?? 0);
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
   const totalTokens = usage.totalTokens ?? inputTokens + outputTokens;
-  const cacheRead =
-    usage.cachedInputTokens ??
-    usage.inputTokenDetails?.cacheReadTokens ??
-    usage.inputTokens?.cacheRead;
+  const cacheRead = usage.inputTokenDetails?.cacheReadTokens;
 
   return { inputTokens, outputTokens, totalTokens, cacheRead };
 }
@@ -43,10 +38,11 @@ function getUsageTotals(usage) {
 async function example1_basicWithUsage() {
   console.log('1  Basic Generation with Usage Tracking\n');
 
-  const { text, usage, response } = await generateText({
+  const { text, usage, finalStep } = await generateText({
     model,
     prompt: 'Explain the concept of native JSON schema support in 2 sentences.',
   });
+  const response = finalStep.response;
 
   console.log(' Response:');
   console.log(text);

--- a/examples/exec/generate-object-advanced.mjs
+++ b/examples/exec/generate-object-advanced.mjs
@@ -14,7 +14,7 @@ import { z } from 'zod';
 console.log(' Codex CLI - Advanced Object Generation\n');
 
 // Use the Codex flagship model to exercise extra-high reasoning effort.
-// Requires the validated Codex CLI 0.130.x line for gpt-5.5 + xhigh.
+// Requires the validated Codex CLI 0.142.x line for gpt-5.5 + xhigh.
 const model = codexExec('gpt-5.5', {
   allowNpx: true,
   skipGitRepoCheck: true,

--- a/examples/exec/long-prompt-test.mjs
+++ b/examples/exec/long-prompt-test.mjs
@@ -95,7 +95,7 @@ async function main() {
 
     const result = await generateText({
       model: codex('gpt-5.5'),
-      system: FRONTEND_PROMPT,
+      instructions: FRONTEND_PROMPT,
       prompt: USER_PROMPT,
     });
 

--- a/examples/exec/streaming-multiple-tools.mjs
+++ b/examples/exec/streaming-multiple-tools.mjs
@@ -26,7 +26,7 @@ try {
   const toolCalls = [];
   const textParts = [];
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'response-metadata': {
         const sessionId = part.providerMetadata?.['codex-cli']?.sessionId;
@@ -106,11 +106,9 @@ try {
           console.log(''.repeat(60));
         }
 
-        const usage = part.totalUsage || part.usage;
-        const inputTotal =
-          typeof usage?.inputTokens === 'number' ? usage.inputTokens : usage?.inputTokens?.total;
-        const outputTotal =
-          typeof usage?.outputTokens === 'number' ? usage.outputTokens : usage?.outputTokens?.total;
+        const usage = part.totalUsage;
+        const inputTotal = usage?.inputTokens;
+        const outputTotal = usage?.outputTokens;
         const usageSummary =
           typeof inputTotal === 'number' || typeof outputTotal === 'number'
             ? `, ${inputTotal ?? 'unknown'} input tokens, ${outputTotal ?? 'unknown'} output tokens`

--- a/examples/exec/streaming-tool-calls.mjs
+++ b/examples/exec/streaming-tool-calls.mjs
@@ -20,7 +20,7 @@ try {
 
   const textBuffer = [];
 
-  for await (const part of result.fullStream) {
+  for await (const part of result.stream) {
     switch (part.type) {
       case 'response-metadata': {
         const sessionId = part.providerMetadata?.['codex-cli']?.sessionId;
@@ -71,7 +71,7 @@ try {
         break;
       }
       case 'text-delta': {
-        // AI SDK fullStream uses .text for text-delta events
+        // AI SDK stream uses .text for text-delta events
         const textDelta = part.text ?? part.delta;
         if (typeof textDelta === 'string') {
           textBuffer.push(textDelta);
@@ -80,11 +80,9 @@ try {
         break;
       }
       case 'finish': {
-        const usage = part.totalUsage || part.usage;
-        const inputTotal =
-          typeof usage?.inputTokens === 'number' ? usage.inputTokens : usage?.inputTokens?.total;
-        const outputTotal =
-          typeof usage?.outputTokens === 'number' ? usage.outputTokens : usage?.outputTokens?.total;
+        const usage = part.totalUsage;
+        const inputTotal = usage?.inputTokens;
+        const outputTotal = usage?.outputTokens;
         if (typeof inputTotal === 'number' || typeof outputTotal === 'number') {
           console.log(
             `\n Finished (inputTokens=${inputTotal ?? 'unknown'}, outputTokens=${outputTotal ?? 'unknown'})`,

--- a/examples/exec/streaming-tool-calls.mjs
+++ b/examples/exec/streaming-tool-calls.mjs
@@ -51,17 +51,9 @@ try {
         console.log(` Executing tool: ${part.toolName} (${part.toolCallId})`);
         break;
       case 'tool-result': {
-        const result = part.result;
+        const output = part.output;
 
-        if (result && typeof result === 'object' && result.type === 'output-delta') {
-          const streamLabel = result.stream ?? 'stdout';
-          if (typeof result.output === 'string' && result.output.length > 0) {
-            console.log(` ${streamLabel}:\n${result.output}`);
-          }
-          break;
-        }
-
-        const payload = result ?? part.providerMetadata?.['codex-cli'];
+        const payload = output ?? part.providerMetadata?.['codex-cli'];
         if (payload) {
           console.log(` Tool result (${part.toolCallId}):\n${JSON.stringify(payload, null, 2)}`);
         } else {

--- a/examples/exec/system-messages.mjs
+++ b/examples/exec/system-messages.mjs
@@ -13,7 +13,7 @@ const model = codexExec('gpt-5.5', {
 
 const { text } = await generateText({
   model,
-  system: 'You are a terse assistant. Always reply in exactly 3 words.',
+  instructions: 'You are a terse assistant. Always reply in exactly 3 words.',
   prompt: 'Describe TypeScript in a nutshell.',
 });
 console.log('System-influenced reply:', text);

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "node": ">=22"
       },
       "optionalDependencies": {
-        "@openai/codex": "^0.130.0"
+        "@openai/codex": "^0.142.5"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -878,9 +878,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0.tgz",
-      "integrity": "sha512-WGDj+RZ3TXWC/7MlwprgLWOqzpwatPIINPhP3IRzHA0ni+o3QZ4i4xrS2uWwGmHUJ395J5JHwoZAAZYyfJyz6w==",
+      "version": "0.142.5",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5.tgz",
+      "integrity": "sha512-WQEpD7l3k68eIAP0aq28EdR18ENBAf8DyprzFhzNwCOQJSv4nHzpwT8Fl30IJacprko2ZCmUBZjM2u941l2yLw==",
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -890,19 +890,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.130.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.130.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.130.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.130.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.130.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.130.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.5-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.5-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.5-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.142.5-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.5-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.142.5-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.130.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-arm64.tgz",
-      "integrity": "sha512-R9pkGC7kwC8yQ8el5hvBlmugQlcsG/pHMEFgZluu03X9fD2TezGxdq3KqRDRCZuMYl07ILamVEoqknuJ0cq7MA==",
+      "version": "0.142.5-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-darwin-arm64.tgz",
+      "integrity": "sha512-l43p8xv+Z/2/b6fCUc7/FmcQZsaPB7RFizLponGwHAnFOWe3i9Vky69p+up3BUam9AetoQQUv7Mo+2KdaFEqhA==",
       "cpu": [
         "arm64"
       ],
@@ -917,9 +917,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.130.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-x64.tgz",
-      "integrity": "sha512-gJ+7J8djevgtdra+NgDAiQQPW+O3KTsgGfE3E5dpDfww3zS5OCeV0V2dhxqnJdlOjOSDw99o0P2LqBv19mhpRw==",
+      "version": "0.142.5-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-darwin-x64.tgz",
+      "integrity": "sha512-yk6A06/VmW7NFsa48OVPaj//g/zeSpd79wjuqfXZwW8ZKRYQm3+wCd3hWjPl79F3QnXvDvM2j3JMIBL3m3GXXg==",
       "cpu": [
         "x64"
       ],
@@ -934,9 +934,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.130.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-arm64.tgz",
-      "integrity": "sha512-tFtH0V9/hEI3d9y7zP92BXI9FM4Z3+STNQaOR52Czv18TRtCFUp7CbIUYaToopuq6UBfnE1VKr8RLhwT5FcbmA==",
+      "version": "0.142.5-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-linux-arm64.tgz",
+      "integrity": "sha512-77ka5PSnm5HdxdBT99IwntCasmbqevlS0eiC0AtEb6ZXCLkim2gm0AWm+jNYy0EhbssvNK+KghayWo34HMgXeA==",
       "cpu": [
         "arm64"
       ],
@@ -951,9 +951,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.130.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-x64.tgz",
-      "integrity": "sha512-3VcNlez99xdnEf+kB1IOpWv9fICYV9PiGj4sLCO4TCcShLnyxe+YBGa3poknkvXLnMG0qiN9SMnYS2FGrMxQcA==",
+      "version": "0.142.5-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-linux-x64.tgz",
+      "integrity": "sha512-pxY+d3NgNE57Y/MApD3/TZUAygxJN6I9h3ZeDUwe67mxWjUxsuapxMRFTKSznCalYbRAeZp752+AAXmUbmguEg==",
       "cpu": [
         "x64"
       ],
@@ -968,9 +968,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.130.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-arm64.tgz",
-      "integrity": "sha512-vdpmiNp57L/arZabltLXn8TyEtNa7W1meOEkr+3R6W/8ZyBt++wuqz1Orv134OT2grrcFJsIVCAIPiqUxCvBkA==",
+      "version": "0.142.5-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-win32-arm64.tgz",
+      "integrity": "sha512-65BEqGbUZ7r0ayunIHdBjo5crwgbwKX/6puOcO+VCswUw/dXvDsN2IGcbXB52+bS9U5+FxP783cUHfTT6m40DQ==",
       "cpu": [
         "arm64"
       ],
@@ -985,9 +985,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.130.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-x64.tgz",
-      "integrity": "sha512-FzMznm7fr5/nbjZgOujZ9Y9AbdGm7ji1FOoWiY3U+srqauvZaTgn6o6aCheSL7kuymu7nTLOO/cAyWV6NuesqQ==",
+      "version": "0.142.5-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-win32-x64.tgz",
+      "integrity": "sha512-a+wI4PEx9a2fg6V5ueTTDkOkr1XpEvA5RFXIbo/L2hOfzMmGtyRnbG24bCGu5Q2RSgVxSQV0aLkdb3vdYMNH9A==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-codex-cli",
-      "version": "1.2.2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/provider": "^3.0.0",
-        "@ai-sdk/provider-utils": "^4.0.1",
+        "@ai-sdk/provider": "^4.0.0",
+        "@ai-sdk/provider-utils": "^5.0.0",
         "jsonc-parser": "^3.3.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.14.0",
-        "@types/node": "20.19.41",
+        "@types/node": "^22.10.2",
         "@vitest/coverage-v8": "^3.2.4",
-        "ai": "^6.0.3",
+        "ai": "^7.0.0",
         "eslint": "^9.14.0",
         "prettier": "^3.3.3",
         "tsup": "8.5.1",
@@ -27,57 +27,58 @@
         "zod": "^4.1.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "optionalDependencies": {
         "@openai/codex": "^0.130.0"
       },
       "peerDependencies": {
-        "zod": "^3.0.0 || ^4.0.0"
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.114",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.114.tgz",
-      "integrity": "sha512-MqkZ5sd+qiq6RgIxELkoFQXg2/JwK+WCMaot7U+rtrZpWJl3fSyYvc28SC03b256o4F7OXjQtdjTqs81B2w+dA==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.12.tgz",
+      "integrity": "sha512-Y7Fy8xJwPz7ZC0DhSQG3HIVk+drup42hrIj6yqKlib3CxwiR0F7nYyUI8+kPrEtbZEoyKoRstvT4/o0HEyFBHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.27",
+        "@ai-sdk/provider": "4.0.2",
+        "@ai-sdk/provider-utils": "5.0.5",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.2.tgz",
+      "integrity": "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.27",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
-      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.5.tgz",
+      "integrity": "sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider": "4.0.2",
         "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
         "eventsource-parser": "^3.0.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -999,16 +1000,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1409,9 +1400,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1859,6 +1850,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1883,19 +1880,18 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.182",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.182.tgz",
-      "integrity": "sha512-ooJdziFjYrYRcsCx107roqA8gDTI3P82nUfroNWIhVvwrkYzEN3W1l50YK+XNqkUew8AiimaW0/SLBewRXMuHQ==",
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.16.tgz",
+      "integrity": "sha512-OuA+uz6ZUVId+SVeB5bThi25Ofee/FmLvffAA368tlgqYCe2qAhqZUpfHL0dd9QC/iPiszdvCQYENJavSo/0gw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.114",
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.27",
-        "@opentelemetry/api": "^1.9.0"
+        "@ai-sdk/gateway": "4.0.12",
+        "@ai-sdk/provider": "4.0.2",
+        "@ai-sdk/provider-utils": "5.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "zod": "^4.1.8"
   },
   "peerDependencies": {
-    "zod": "^3.25.76 || ^4.1.8"
+    "zod": "^4.1.8"
   },
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,17 +1,14 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "1.2.2",
-  "description": "AI SDK v6 provider for OpenAI Codex CLI (use ChatGPT Plus/Pro subscription)",
+  "version": "2.0.0",
+  "description": "AI SDK v7 provider for OpenAI Codex CLI (use ChatGPT Plus/Pro subscription)",
   "keywords": [
     "ai-sdk",
     "codex",
     "openai",
     "cli",
     "language-model",
-    "gpt-5",
-    "gpt-5.1",
     "gpt-5.5",
-    "gpt-5.2-codex-max",
     "provider"
   ],
   "homepage": "https://github.com/ben-vargas/ai-sdk-provider-codex-cli",
@@ -26,15 +23,12 @@
   "author": "Ben Vargas",
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "files": [
@@ -62,8 +56,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@ai-sdk/provider": "^3.0.0",
-    "@ai-sdk/provider-utils": "^4.0.1",
+    "@ai-sdk/provider": "^4.0.0",
+    "@ai-sdk/provider-utils": "^5.0.0",
     "jsonc-parser": "^3.3.1"
   },
   "optionalDependencies": {
@@ -71,9 +65,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",
-    "@types/node": "20.19.41",
+    "@types/node": "^22.10.2",
     "@vitest/coverage-v8": "^3.2.4",
-    "ai": "^6.0.3",
+    "ai": "^7.0.0",
     "eslint": "^9.14.0",
     "prettier": "^3.3.3",
     "tsup": "8.5.1",
@@ -83,10 +77,10 @@
     "zod": "^4.1.8"
   },
   "peerDependencies": {
-    "zod": "^3.0.0 || ^4.0.0"
+    "zod": "^3.25.76 || ^4.1.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jsonc-parser": "^3.3.1"
   },
   "optionalDependencies": {
-    "@openai/codex": "^0.130.0"
+    "@openai/codex": "^0.142.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",

--- a/scripts/sync-protocol-types.sh
+++ b/scripts/sync-protocol-types.sh
@@ -2,8 +2,12 @@
 set -euo pipefail
 
 OUT_DIR=${1:-/tmp/codex-protocol-ref}
+# Override with the exact CLI you are syncing against, e.g.
+#   CODEX_BIN=~/.local/bin/codex scripts/sync-protocol-types.sh
+# The locally installed optional-dep binary may not match the target release.
+CODEX_BIN=${CODEX_BIN:-codex}
 
-codex app-server generate-ts --experimental --out "$OUT_DIR"
+"$CODEX_BIN" app-server generate-ts --experimental --out "$OUT_DIR"
 
 echo "Generated protocol reference types in: $OUT_DIR"
 echo "Copy the needed subset into src/app-server/protocol/types.ts and update validators/tests."

--- a/scripts/validate-doc-snippets.mjs
+++ b/scripts/validate-doc-snippets.mjs
@@ -18,6 +18,11 @@ const markdownFiles = [
   'docs/ai-sdk-v5/troubleshooting.md',
   'docs/ai-sdk-v5/limitations.md',
   'docs/ai-sdk-v5/migration-app-server-v2.md',
+  'docs/ai-sdk-v7/guide.md',
+  'docs/ai-sdk-v7/configuration.md',
+  'docs/ai-sdk-v7/troubleshooting.md',
+  'docs/ai-sdk-v7/limitations.md',
+  'docs/ai-sdk-v7/migration-v6-to-v7.md',
 ].filter((file) => existsSync(join(repoRoot, file)));
 
 const failures = [];

--- a/src/__tests__/ai-sdk-v7-integration.test.ts
+++ b/src/__tests__/ai-sdk-v7-integration.test.ts
@@ -2,20 +2,25 @@
  * End-to-end integration tests: AI SDK v7 (`ai` package) <-> this provider.
  *
  * These tests call the provider exclusively through the real `ai@7`
- * entrypoints (generateText, streamText, generateObject) so that any
- * spec-version or shape mismatch between ai@7 and the LanguageModelV4
- * implementation fails loudly. The Codex CLI child process is mocked at the
- * `node:child_process` boundary using the same pattern as
- * exec-language-model.test.ts; everything between `ai` and `spawn` is real.
+ * entrypoints (generateText, streamText, generateObject, streamObject) so
+ * that any spec-version or shape mismatch between ai@7 and the
+ * LanguageModelV4 implementation fails loudly. For the exec provider the
+ * Codex CLI child process is mocked at the `node:child_process` boundary
+ * using the same pattern as exec-language-model.test.ts; for the app-server
+ * provider the JSON-RPC client is faked using the same pattern as
+ * app-server-language-model.test.ts. Everything between `ai` and those
+ * boundaries is real.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { generateText, streamText, generateObject } from 'ai';
+import { generateText, streamText, generateObject, streamObject } from 'ai';
 import { z } from 'zod';
 import * as childProcess from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { createCodexExec } from '../index.js';
+import { AppServerLanguageModel } from '../app-server/language-model.js';
+import type { TurnStartParams } from '../app-server/protocol/types.js';
 
 interface MockChildProcess extends EventEmitter {
   stdout: PassThrough;
@@ -184,14 +189,15 @@ describe('AI SDK v7 integration (exec provider)', () => {
     expect(capture.stdin()).toContain('User: Say hi');
   });
 
-  // KNOWN BUG (do not "fix" this test — fix the provider): ai@7 normalizes an
-  // unset toolChoice to { type: 'auto' } before calling the model, and the
-  // provider warns on ANY defined toolChoice. A bare generateText call should
-  // be warning-free. Marked `.fails` so it passes while the bug exists and
-  // flags loudly once the provider stops warning on ai@7's default toolChoice
-  // (then remove `.fails`).
-  it.fails('a bare generateText call surfaces no unsupported-setting warnings', async () => {
+  it('a bare generateText call surfaces no unsupported-setting warnings', async () => {
     installCapturingSpawn(codexTurn('plain'));
+
+    // ai@7 normalizes an unset toolChoice to { type: 'auto' } before calling
+    // the model; the provider treats that default as carrying no user intent,
+    // so a bare call is warning-free end to end. In Node, ai@7 routes warning
+    // noise through process.emitWarning (console.warn is only its fallback).
+    const emitWarningSpy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const result = await generateText({
       model: provider('gpt-5'),
@@ -199,6 +205,36 @@ describe('AI SDK v7 integration (exec provider)', () => {
     });
 
     expect(result.warnings ?? []).toEqual([]);
+    // With zero warnings, ai@7's warning logger stays silent — no process
+    // warning noise from a plain call.
+    const aiSdkNoise = emitWarningSpy.mock.calls.filter(([message]) =>
+      String(message).includes('AI SDK Warning'),
+    );
+    expect(aiSdkNoise).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('a meaningful toolChoice still yields the unsupported-setting warning', async () => {
+    installCapturingSpawn(codexTurn('plain'));
+
+    // Swallow ai@7's warning noise so the suite output stays clean; the spy
+    // doubles as the observable end of the warning pipeline.
+    const emitWarningSpy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const result = await generateText({
+      model: provider('gpt-5'),
+      prompt: 'Force a tool',
+      toolChoice: 'required',
+    });
+
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ type: 'unsupported', feature: 'toolChoice' }),
+    );
+    expect(emitWarningSpy).toHaveBeenCalledWith(
+      expect.stringContaining('toolChoice'),
+      expect.anything(),
+    );
   });
 
   it('streamText yields text deltas and a finish part via result.stream', async () => {
@@ -260,6 +296,37 @@ describe('AI SDK v7 integration (exec provider)', () => {
       },
     });
     expect(schemaJson.required).toEqual(expect.arrayContaining(['name', 'age']));
+  });
+
+  it('streamObject yields partials and resolves the final object from codex JSON output', async () => {
+    const capture = installCapturingSpawn(
+      codexTurn('{"name":"Grace Hopper","age":45}', 'thread-stream-obj'),
+    );
+
+    const result = streamObject({
+      model: provider('gpt-5'),
+      schema: z.object({ name: z.string(), age: z.number() }),
+      prompt: 'Extract the person',
+    });
+
+    const partials: unknown[] = [];
+    for await (const partial of result.partialObjectStream) {
+      partials.push(partial);
+    }
+
+    // The exec JSONL surface carries no text deltas (assistant text arrives
+    // only via item.completed), so the provider emits the complete JSON as a
+    // single text-delta at process close: the partial stream produces at
+    // least one partial, and the last one is already the finished object.
+    expect(partials.length).toBeGreaterThanOrEqual(1);
+    expect(partials.at(-1)).toEqual({ name: 'Grace Hopper', age: 45 });
+
+    await expect(result.object).resolves.toEqual({ name: 'Grace Hopper', age: 45 });
+
+    // The zod schema flowed through ai@7's responseFormat into the STREAMING
+    // CLI invocation's --output-schema temp file (doStream plumbing, distinct
+    // from the generateObject/doGenerate path above).
+    expect(capture.args).toContain('--output-schema');
   });
 
   it('top-level reasoning option maps to the codex reasoning-effort config', async () => {
@@ -350,5 +417,114 @@ describe('AI SDK v7 integration (exec provider)', () => {
     // falling into an unsupported-image warning.
     const warningText = JSON.stringify(result.warnings ?? []);
     expect(warningText).not.toMatch(/image/i);
+  });
+});
+
+/**
+ * Minimal app-server JSON-RPC fake (same pattern as
+ * app-server-language-model.test.ts): `turnStart` drives notifications over
+ * the shared EventEmitter channel the provider's router subscribes to.
+ */
+class FakeAppServerClient extends EventEmitter {
+  turnStartCalls: TurnStartParams[] = [];
+  turnStartImpl?: (params: TurnStartParams) => Promise<{ turn: { id: string } }>;
+  private nextContextId = 1;
+
+  async threadStart(_params: unknown) {
+    return {
+      thread: { id: 'thr_v7' },
+      model: 'gpt-5.3-codex',
+      modelProvider: 'openai',
+      cwd: '/tmp',
+      approvalPolicy: 'never',
+      sandbox: { type: 'workspaceWrite' },
+      reasoningEffort: null,
+    };
+  }
+
+  async turnStart(params: TurnStartParams) {
+    this.turnStartCalls.push(params);
+    if (!this.turnStartImpl) throw new Error('turnStartImpl not installed for this test');
+    return await this.turnStartImpl(params);
+  }
+
+  async turnInterrupt(_params: { threadId: string; turnId: string }) {
+    return {};
+  }
+
+  async withThreadLock(_threadId: string, fn: () => Promise<unknown>) {
+    return await fn();
+  }
+
+  registerRequestContext(
+    _threadId: string,
+    _context: { handlers: Record<string, unknown>; autoApprove?: boolean },
+  ): string {
+    return `ctx_${this.nextContextId++}`;
+  }
+
+  bindRequestContext(_contextId: string, _turnId: string) {}
+
+  clearRequestContext(_contextId: string) {}
+
+  clearRequestContextForTurn(_turnId: string) {}
+
+  hasTurnCompleted(_turnId: string): boolean {
+    return false;
+  }
+}
+
+describe('AI SDK v7 integration (app-server provider)', () => {
+  it('streamObject resolves the object built from json-mode buffered deltas', async () => {
+    const client = new FakeAppServerClient();
+    client.turnStartImpl = async (params) => {
+      // Emit asynchronously (deterministic, no wall-clock delay) so the turn
+      // id is bound before the notifications arrive.
+      setImmediate(() => {
+        client.emit('notification', 'item/agentMessage/delta', {
+          threadId: params.threadId,
+          turnId: 'turn_json_1',
+          itemId: 'item_json_1',
+          delta: '{"name":"Grace Hopper"',
+        });
+        client.emit('notification', 'item/agentMessage/delta', {
+          threadId: params.threadId,
+          turnId: 'turn_json_1',
+          itemId: 'item_json_1',
+          delta: ',"age":45}',
+        });
+        client.emit('notification', 'turn/completed', {
+          threadId: params.threadId,
+          turn: { id: 'turn_json_1', items: [], status: 'completed', error: null },
+        });
+      });
+      return { turn: { id: 'turn_json_1' } };
+    };
+
+    const model = new AppServerLanguageModel({ id: 'gpt-5.3-codex', client: client as never });
+
+    const result = streamObject({
+      model: model as never,
+      schema: z.object({ name: z.string(), age: z.number() }),
+      prompt: 'Extract the person',
+    });
+
+    const partials: unknown[] = [];
+    for await (const partial of result.partialObjectStream) {
+      partials.push(partial);
+    }
+
+    // In JSON mode the emitter (jsonModeLastTextBlockOnly) buffers every
+    // incremental text delta and replays only the LAST completed text block
+    // as a single text-delta at finish, so ai@7 never observes incremental
+    // JSON: the partial stream collapses to exactly one partial — the
+    // completed object.
+    expect(partials).toEqual([{ name: 'Grace Hopper', age: 45 }]);
+
+    await expect(result.object).resolves.toEqual({ name: 'Grace Hopper', age: 45 });
+
+    // The json responseFormat flowed into turn/start as an outputSchema.
+    const turnStart = client.turnStartCalls[0] as TurnStartParams & { outputSchema?: unknown };
+    expect(turnStart?.outputSchema).toMatchObject({ type: 'object' });
   });
 });

--- a/src/__tests__/ai-sdk-v7-integration.test.ts
+++ b/src/__tests__/ai-sdk-v7-integration.test.ts
@@ -427,10 +427,12 @@ describe('AI SDK v7 integration (exec provider)', () => {
  */
 class FakeAppServerClient extends EventEmitter {
   turnStartCalls: TurnStartParams[] = [];
+  threadStartCalls: unknown[] = [];
   turnStartImpl?: (params: TurnStartParams) => Promise<{ turn: { id: string } }>;
   private nextContextId = 1;
 
-  async threadStart(_params: unknown) {
+  async threadStart(params: unknown) {
+    this.threadStartCalls.push(params);
     return {
       thread: { id: 'thr_v7' },
       model: 'gpt-5.3-codex',
@@ -526,5 +528,56 @@ describe('AI SDK v7 integration (app-server provider)', () => {
     // The json responseFormat flowed into turn/start as an outputSchema.
     const turnStart = client.turnStartCalls[0] as TurnStartParams & { outputSchema?: unknown };
     expect(turnStart?.outputSchema).toMatchObject({ type: 'object' });
+  });
+
+  it('streamText include.rawChunks enables app-server raw chunks through ai@7', async () => {
+    const client = new FakeAppServerClient();
+    client.turnStartImpl = async (params) => {
+      setImmediate(() => {
+        client.emit('notification', 'item/agentMessage/delta', {
+          threadId: params.threadId,
+          turnId: 'turn_raw_v7',
+          itemId: 'item_raw_v7',
+          delta: 'raw text',
+        });
+        client.emit('notification', 'turn/completed', {
+          threadId: params.threadId,
+          turn: { id: 'turn_raw_v7', items: [], status: 'completed', error: null },
+        });
+      });
+      return { turn: { id: 'turn_raw_v7' } };
+    };
+
+    const model = new AppServerLanguageModel({ id: 'gpt-5.3-codex', client: client as never });
+
+    const result = streamText({
+      model: model as never,
+      prompt: 'Stream with raw chunks',
+      include: { rawChunks: true },
+    });
+
+    const parts: unknown[] = [];
+    for await (const part of result.stream) {
+      parts.push(part);
+    }
+
+    function isRawDeltaNotification(part: unknown): part is {
+      type: 'raw';
+      rawValue: { method?: unknown };
+    } {
+      if (part === null || typeof part !== 'object' || !('type' in part)) return false;
+      if (part.type !== 'raw' || !('rawValue' in part)) return false;
+      const rawValue = part.rawValue;
+      return (
+        rawValue !== null &&
+        typeof rawValue === 'object' &&
+        'method' in rawValue &&
+        rawValue.method === 'item/agentMessage/delta'
+      );
+    }
+
+    expect(parts.some(isRawDeltaNotification)).toBe(true);
+    const [threadStart] = client.threadStartCalls;
+    expect(threadStart).toMatchObject({ experimentalRawEvents: true });
   });
 });

--- a/src/__tests__/ai-sdk-v7-integration.test.ts
+++ b/src/__tests__/ai-sdk-v7-integration.test.ts
@@ -1,0 +1,354 @@
+/**
+ * End-to-end integration tests: AI SDK v7 (`ai` package) <-> this provider.
+ *
+ * These tests call the provider exclusively through the real `ai@7`
+ * entrypoints (generateText, streamText, generateObject) so that any
+ * spec-version or shape mismatch between ai@7 and the LanguageModelV4
+ * implementation fails loudly. The Codex CLI child process is mocked at the
+ * `node:child_process` boundary using the same pattern as
+ * exec-language-model.test.ts; everything between `ai` and `spawn` is real.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateText, streamText, generateObject } from 'ai';
+import { z } from 'zod';
+import * as childProcess from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createCodexExec } from '../index.js';
+
+interface MockChildProcess extends EventEmitter {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  stdin: PassThrough;
+  kill: (signal?: string) => void;
+  /** Returns everything the provider wrote to the child's stdin (the prompt). */
+  _stdinData: () => string;
+}
+
+type SpawnFn = (cmd: string, args: string[]) => MockChildProcess;
+
+interface MockableChildProcess {
+  __setSpawnMock: (fn: SpawnFn) => void;
+}
+
+vi.mock('node:child_process', () => {
+  let currentSpawn: ((cmd: string, args: string[]) => unknown) | undefined;
+  return {
+    spawn: (cmd: string, args: string[]) => {
+      if (!currentSpawn) throw new Error('spawn mock not installed for this test');
+      return currentSpawn(cmd, args);
+    },
+    __setSpawnMock: (fn: (cmd: string, args: string[]) => unknown) => {
+      currentSpawn = fn;
+    },
+  };
+});
+
+// The vi.mock factory augments the mocked module with __setSpawnMock, which
+// the node:child_process module type cannot express.
+const mockableChildProcess = childProcess as unknown as MockableChildProcess;
+
+/** Emits the given JSONL lines on stdout, then closes with the exit code. */
+function makeMockSpawn(lines: string[], exitCode = 0): SpawnFn {
+  return (_cmd, args) => {
+    const child = new EventEmitter() as MockChildProcess;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.stdin = new PassThrough();
+    child.kill = vi.fn();
+
+    let stdinData = '';
+    child.stdin.on('data', (chunk: Buffer) => {
+      stdinData += chunk.toString();
+    });
+
+    // Mirror the real CLI: --output-last-message file gets the final text.
+    const idx = args.indexOf('--output-last-message');
+    const lastMessagePath = idx !== -1 ? args[idx + 1] : undefined;
+    if (lastMessagePath) {
+      try {
+        writeFileSync(lastMessagePath, 'Fallback last message\n');
+      } catch {
+        // best-effort, like the real CLI
+      }
+    }
+
+    // Emit asynchronously (deterministic, no wall-clock delay) so the
+    // provider has attached its stdout listeners before data flows.
+    setImmediate(() => {
+      for (const l of lines) child.stdout.write(l + '\n');
+      child.stdout.end();
+      child.emit('close', exitCode);
+    });
+
+    child._stdinData = () => stdinData;
+    return child;
+  };
+}
+
+/**
+ * What the provider actually handed to the (mocked) codex process.
+ * Temp files (--output-schema, --image) are snapshotted at spawn time,
+ * before the provider deletes them on process close.
+ */
+interface SpawnCapture {
+  cmd: string;
+  args: string[];
+  stdin: () => string;
+  schemaFileAtSpawn: string | undefined;
+  imageFilesAtSpawn: Buffer[];
+}
+
+function installCapturingSpawn(lines: string[]): SpawnCapture {
+  const capture: SpawnCapture = {
+    cmd: '',
+    args: [],
+    stdin: () => '',
+    schemaFileAtSpawn: undefined,
+    imageFilesAtSpawn: [],
+  };
+
+  mockableChildProcess.__setSpawnMock((cmd, args) => {
+    capture.cmd = cmd;
+    capture.args = [...args];
+
+    const schemaIdx = args.indexOf('--output-schema');
+    const schemaPath = schemaIdx === -1 ? undefined : args[schemaIdx + 1];
+    if (schemaPath) {
+      capture.schemaFileAtSpawn = readFileSync(schemaPath, 'utf8');
+    }
+
+    for (let i = 0; i < args.length - 1; i += 1) {
+      const value = args[i + 1];
+      if (args[i] === '--image' && value) {
+        capture.imageFilesAtSpawn.push(readFileSync(value));
+      }
+    }
+
+    const child = makeMockSpawn(lines)(cmd, args);
+    capture.stdin = () => child._stdinData();
+    return child;
+  });
+
+  return capture;
+}
+
+function codexTurn(text: string, threadId = 'thread-v7'): string[] {
+  return [
+    JSON.stringify({ type: 'thread.started', thread_id: threadId }),
+    JSON.stringify({
+      type: 'item.completed',
+      item: { item_type: 'assistant_message', text },
+    }),
+    JSON.stringify({
+      type: 'turn.completed',
+      usage: { input_tokens: 12, output_tokens: 7 },
+    }),
+  ];
+}
+
+const provider = createCodexExec({
+  defaultSettings: { allowNpx: true, color: 'never' },
+});
+
+describe('AI SDK v7 integration (exec provider)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('generateText returns the text produced by the codex output', async () => {
+    const capture = installCapturingSpawn(
+      codexTurn('Hello from Codex via AI SDK v7', 'thread-gen'),
+    );
+
+    const result = await generateText({
+      model: provider('gpt-5'),
+      prompt: 'Say hi',
+    });
+
+    expect(result.text).toBe('Hello from Codex via AI SDK v7');
+    expect(result.finishReason).toBe('stop');
+    // v4 nested usage is mapped into ai@7's flat usage numbers.
+    expect(result.usage.inputTokens).toBe(12);
+    expect(result.usage.outputTokens).toBe(7);
+    // Provider metadata (session id) survives the round trip.
+    expect(result.finalStep.providerMetadata?.['codex-cli']).toMatchObject({
+      sessionId: 'thread-gen',
+    });
+    // The model id chosen through the v7 provider call routes into the CLI.
+    const modelFlag = capture.args.indexOf('-m');
+    expect(modelFlag).toBeGreaterThan(-1);
+    expect(capture.args[modelFlag + 1]).toBe('gpt-5');
+    // The prompt text actually reaches codex on stdin.
+    expect(capture.stdin()).toContain('User: Say hi');
+  });
+
+  // KNOWN BUG (do not "fix" this test — fix the provider): ai@7 normalizes an
+  // unset toolChoice to { type: 'auto' } before calling the model, and the
+  // provider warns on ANY defined toolChoice. A bare generateText call should
+  // be warning-free. Marked `.fails` so it passes while the bug exists and
+  // flags loudly once the provider stops warning on ai@7's default toolChoice
+  // (then remove `.fails`).
+  it.fails('a bare generateText call surfaces no unsupported-setting warnings', async () => {
+    installCapturingSpawn(codexTurn('plain'));
+
+    const result = await generateText({
+      model: provider('gpt-5'),
+      prompt: 'Plain call',
+    });
+
+    expect(result.warnings ?? []).toEqual([]);
+  });
+
+  it('streamText yields text deltas and a finish part via result.stream', async () => {
+    installCapturingSpawn(codexTurn('Streamed via v7', 'thread-stream'));
+
+    const result = streamText({
+      model: provider('gpt-5'),
+      prompt: 'Stream it',
+    });
+
+    let streamedText = '';
+    let sawTextStart = false;
+    let sawTextEnd = false;
+    let finishReason: string | undefined;
+    let finishOutputTokens: number | undefined;
+
+    for await (const part of result.stream) {
+      if (part.type === 'text-start') sawTextStart = true;
+      if (part.type === 'text-delta') streamedText += part.text;
+      if (part.type === 'text-end') sawTextEnd = true;
+      if (part.type === 'finish') {
+        finishReason = part.finishReason;
+        finishOutputTokens = part.totalUsage.outputTokens;
+      }
+    }
+
+    expect(streamedText).toBe('Streamed via v7');
+    expect(sawTextStart).toBe(true);
+    expect(sawTextEnd).toBe(true);
+    expect(finishReason).toBe('stop');
+    expect(finishOutputTokens).toBe(7);
+    await expect(result.text).resolves.toBe('Streamed via v7');
+  });
+
+  it('generateObject parses codex JSON output and sends the zod schema via --output-schema', async () => {
+    const capture = installCapturingSpawn(
+      codexTurn('{"name":"Ada Lovelace","age":36}', 'thread-obj'),
+    );
+
+    const result = await generateObject({
+      model: provider('gpt-5'),
+      schema: z.object({ name: z.string(), age: z.number() }),
+      prompt: 'Extract the person',
+    });
+
+    expect(result.object).toEqual({ name: 'Ada Lovelace', age: 36 });
+
+    // The zod schema flowed through ai@7's responseFormat into the CLI's
+    // --output-schema temp file (snapshotted before the provider cleaned it up).
+    expect(capture.args).toContain('--output-schema');
+    expect(capture.schemaFileAtSpawn).toBeDefined();
+    const schemaJson = JSON.parse(capture.schemaFileAtSpawn ?? '{}') as Record<string, unknown>;
+    expect(schemaJson).toMatchObject({
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'number' },
+      },
+    });
+    expect(schemaJson.required).toEqual(expect.arrayContaining(['name', 'age']));
+  });
+
+  it('top-level reasoning option maps to the codex reasoning-effort config', async () => {
+    const capture = installCapturingSpawn(codexTurn('Thought hard.'));
+
+    await generateText({
+      model: provider('gpt-5'),
+      prompt: 'Think hard',
+      reasoning: 'high',
+    });
+
+    expect(capture.args.join(' ')).toContain('-c model_reasoning_effort=high');
+  });
+
+  it('provider-specific reasoningEffort wins over the top-level reasoning option', async () => {
+    const capture = installCapturingSpawn(codexTurn('Thought a little.'));
+
+    await generateText({
+      model: provider('gpt-5'),
+      prompt: 'Think a little',
+      reasoning: 'high',
+      providerOptions: { 'codex-cli': { reasoningEffort: 'low' } },
+    });
+
+    const joined = capture.args.join(' ');
+    expect(joined).toContain('model_reasoning_effort=low');
+    expect(joined).not.toContain('model_reasoning_effort=high');
+  });
+
+  it('instructions arrive as system guidance ahead of the user turn in the prompt', async () => {
+    const capture = installCapturingSpawn(codexTurn('Bonjour !'));
+
+    const result = await generateText({
+      model: provider('gpt-5'),
+      instructions: 'Answer only in French.',
+      prompt: 'Greet me',
+    });
+
+    expect(result.text).toBe('Bonjour !');
+    const stdin = capture.stdin();
+    expect(stdin).toContain('Answer only in French.');
+    expect(stdin).toContain('User: Greet me');
+    // System guidance precedes the user turn.
+    expect(stdin.indexOf('Answer only in French.')).toBeLessThan(stdin.indexOf('User: Greet me'));
+  });
+
+  it('a v4 tagged-data image file part flows into the --image temp-file pathway', async () => {
+    const capture = installCapturingSpawn(codexTurn('A tiny PNG'));
+
+    // PNG signature + start of an IHDR chunk.
+    const pngBytes = Uint8Array.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+      0x52,
+    ]);
+
+    const result = await generateText({
+      model: provider('gpt-5'),
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe this image' },
+            { type: 'file', mediaType: 'image/png', data: { type: 'data', data: pngBytes } },
+          ],
+        },
+      ],
+    });
+
+    expect(result.text).toBe('A tiny PNG');
+
+    // The image bytes were written to a temp file and passed via --image,
+    // byte-for-byte identical to the original input.
+    expect(capture.args).toContain('--image');
+    expect(capture.imageFilesAtSpawn).toHaveLength(1);
+    const [imageFile] = capture.imageFilesAtSpawn;
+    if (!imageFile) throw new Error('expected an --image temp file at spawn time');
+    expect(Buffer.compare(imageFile, Buffer.from(pngBytes))).toBe(0);
+
+    // Regression guard (issue #19): '--' must separate the greedy --image
+    // flag from the '-' stdin marker.
+    expect(capture.args.at(-2)).toBe('--');
+    expect(capture.args.at(-1)).toBe('-');
+
+    // The user turn carries the attachment marker on stdin.
+    expect(capture.stdin()).toContain('[1 image attached]');
+
+    // Conversion is warning-free: the tagged-data path succeeded rather than
+    // falling into an unsupported-image warning.
+    const warningText = JSON.stringify(result.warnings ?? []);
+    expect(warningText).not.toMatch(/image/i);
+  });
+});

--- a/src/__tests__/app-server-integration.smoke.test.ts
+++ b/src/__tests__/app-server-integration.smoke.test.ts
@@ -14,7 +14,7 @@ describeIntegration('app-server integration smoke', () => {
       const modelId = process.env.CODEX_APP_SERVER_INTEGRATION_MODEL ?? 'gpt-5.3-codex';
       const provider = createCodexAppServer({
         defaultSettings: {
-          minCodexVersion: '0.130.0',
+          minCodexVersion: '0.142.5',
           connectionTimeoutMs: 60_000,
           codexPath,
           approvalPolicy: 'never',

--- a/src/__tests__/app-server-language-model.test.ts
+++ b/src/__tests__/app-server-language-model.test.ts
@@ -576,7 +576,7 @@ describe('AppServerLanguageModel', () => {
 
     const result = await model.doGenerate({
       prompt: [
-        { role: 'system', content: 'ignored' },
+        { role: 'system', content: 'Resume system guidance' },
         { role: 'user', content: 'First' },
         { role: 'assistant', content: 'ignored assistant history' },
         { role: 'user', content: 'Second' },
@@ -585,7 +585,12 @@ describe('AppServerLanguageModel', () => {
     });
 
     expect(client.threadResumeCalls).toHaveLength(1);
-    expect((client.threadResumeCalls[0] as { threadId: string }).threadId).toBe('thr_existing');
+    const resumeCall = client.threadResumeCalls[0] as {
+      threadId: string;
+      developerInstructions?: string;
+    };
+    expect(resumeCall.threadId).toBe('thr_existing');
+    expect(resumeCall.developerInstructions).toBe('Resume system guidance');
     const firstInput = ((client.turnStartCalls[0] as TurnStartParams).input[0] as { text?: string })
       .text;
     expect(firstInput).toBe('Second');
@@ -1519,6 +1524,91 @@ describe('AppServerLanguageModel', () => {
           warning.message.includes('includeRawChunks was requested while resuming an existing'),
       ),
     ).toBe(false);
+  });
+
+  it('does not warn when stateless thread resume uses known raw-event negotiation', async () => {
+    const client = new FakeClient();
+    const model = new AppServerLanguageModel({
+      id: 'gpt-5.3-codex',
+      client: client as never,
+    });
+
+    const first = await model.doGenerate({
+      prompt: [{ role: 'user', content: 'First raw stateless turn' }] as never,
+      includeRawChunks: true,
+    });
+    const threadId = (first.providerMetadata?.['codex-app-server'] as { threadId?: string })
+      ?.threadId;
+
+    const resumed = await model.doGenerate({
+      prompt: [
+        { role: 'user', content: 'Older stateless turn' },
+        { role: 'assistant', content: 'Earlier answer' },
+        { role: 'user', content: 'Second raw stateless turn' },
+      ] as never,
+      includeRawChunks: true,
+      providerOptions: { 'codex-app-server': { threadId } },
+    });
+
+    expect(client.threadResumeCalls).toHaveLength(1);
+    expect((client.threadResumeCalls[0] as { threadId?: string }).threadId).toBe(threadId);
+    expect(
+      resumed.warnings.some(
+        (warning) =>
+          warning.type === 'other' &&
+          warning.message.includes('includeRawChunks was requested while resuming an existing'),
+      ),
+    ).toBe(false);
+  });
+
+  it('warns when raw chunks are requested while resuming an unknown external thread', async () => {
+    const client = new FakeClient();
+    const model = new AppServerLanguageModel({
+      id: 'gpt-5.3-codex',
+      client: client as never,
+    });
+
+    const result = await model.doGenerate({
+      prompt: [{ role: 'user', content: 'Resume unknown raw thread' }] as never,
+      includeRawChunks: true,
+      providerOptions: { 'codex-app-server': { threadId: 'thr_external_raw' } },
+    });
+
+    expect(
+      result.warnings.some(
+        (warning) =>
+          warning.type === 'other' &&
+          warning.message.includes('includeRawChunks was requested while resuming an existing'),
+      ),
+    ).toBe(true);
+  });
+
+  it('warns when a stateless thread without raw-event negotiation resumes with raw chunks', async () => {
+    const client = new FakeClient();
+    const model = new AppServerLanguageModel({
+      id: 'gpt-5.3-codex',
+      client: client as never,
+    });
+
+    const first = await model.doGenerate({
+      prompt: [{ role: 'user', content: 'First non-raw stateless turn' }] as never,
+    });
+    const threadId = (first.providerMetadata?.['codex-app-server'] as { threadId?: string })
+      ?.threadId;
+
+    const resumed = await model.doGenerate({
+      prompt: [{ role: 'user', content: 'Second raw stateless turn' }] as never,
+      includeRawChunks: true,
+      providerOptions: { 'codex-app-server': { threadId } },
+    });
+
+    expect(
+      resumed.warnings.some(
+        (warning) =>
+          warning.type === 'other' &&
+          warning.message.includes('includeRawChunks was requested while resuming an existing'),
+      ),
+    ).toBe(true);
   });
 
   it('invokes onSessionCreated and supports injectMessage()', async () => {

--- a/src/__tests__/app-server-language-model.test.ts
+++ b/src/__tests__/app-server-language-model.test.ts
@@ -1473,6 +1473,43 @@ describe('AppServerLanguageModel', () => {
     ).toBe(true);
   });
 
+  it('preserves raw-event negotiation when explicitly resuming the known persistent thread', async () => {
+    const client = new FakeClient();
+    const model = new AppServerLanguageModel({
+      id: 'gpt-5.3-codex',
+      client: client as never,
+      settings: { threadMode: 'persistent', includeRawChunks: true },
+    });
+
+    await model.doGenerate({
+      prompt: [{ role: 'user', content: 'First' }] as never,
+    });
+
+    const explicitResume = await model.doGenerate({
+      prompt: [{ role: 'user', content: 'Second' }] as never,
+      providerOptions: { 'codex-app-server': { threadId: 'thr_new' } },
+    });
+
+    const continuedPersistent = await model.doGenerate({
+      prompt: [{ role: 'user', content: 'Third' }] as never,
+    });
+
+    expect(
+      explicitResume.warnings.some(
+        (warning) =>
+          warning.type === 'other' &&
+          warning.message.includes('includeRawChunks was requested while resuming an existing'),
+      ),
+    ).toBe(false);
+    expect(
+      continuedPersistent.warnings.some(
+        (warning) =>
+          warning.type === 'other' &&
+          warning.message.includes('includeRawChunks was requested while resuming an existing'),
+      ),
+    ).toBe(false);
+  });
+
   it('invokes onSessionCreated and supports injectMessage()', async () => {
     const client = new FakeClient();
     let session:

--- a/src/__tests__/app-server-language-model.test.ts
+++ b/src/__tests__/app-server-language-model.test.ts
@@ -1144,7 +1144,11 @@ describe('AppServerLanguageModel', () => {
     });
     await flush(1);
     const secondPromise = model.doGenerate({
-      prompt: [{ role: 'user', content: 'Second concurrent' }] as never,
+      prompt: [
+        { role: 'user', content: 'Older concurrent history' },
+        { role: 'assistant', content: 'Assistant history' },
+        { role: 'user', content: 'Second concurrent' },
+      ] as never,
       providerOptions: {
         'codex-app-server': {
           configOverrides: { race_token: 'second-call' },
@@ -1176,6 +1180,13 @@ describe('AppServerLanguageModel', () => {
     expect(firstThreadId).toBe('thr_created_1');
     expect(secondThreadId).toBe('thr_created_1');
     expect(client.withThreadLockCalls).toEqual(['thr_created_1', 'thr_created_1']);
+
+    const secondTurnInput = (
+      (client.turnStartCalls[1] as TurnStartParams).input[0] as {
+        text?: string;
+      }
+    ).text;
+    expect(secondTurnInput).toBe('Second concurrent');
   });
 
   it('throws clear stale-thread error when persistent thread resume fails', async () => {

--- a/src/__tests__/app-server-language-model.test.ts
+++ b/src/__tests__/app-server-language-model.test.ts
@@ -236,7 +236,7 @@ describe('AppServerLanguageModel', () => {
     expect((client.turnStartCalls[0] as TurnStartParams).effort).toBe('minimal');
   });
 
-  it('warns and unsets effort for unmappable reasoning values', async () => {
+  it('warns and keeps configured effort for unmappable reasoning values', async () => {
     const client = new FakeClient();
     const model = new AppServerLanguageModel({
       id: 'gpt-5.3-codex',
@@ -249,9 +249,13 @@ describe('AppServerLanguageModel', () => {
       reasoning: 'ultra' as never,
     });
 
-    expect((client.turnStartCalls[0] as TurnStartParams).effort).toBeUndefined();
+    expect((client.turnStartCalls[0] as TurnStartParams).effort).toBe('medium');
     expect(result.warnings).toContainEqual(
-      expect.objectContaining({ type: 'unsupported', feature: 'reasoning' }),
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'reasoning',
+        details: expect.stringContaining("'ultra'; it will be ignored"),
+      }),
     );
   });
 

--- a/src/__tests__/app-server-language-model.test.ts
+++ b/src/__tests__/app-server-language-model.test.ts
@@ -174,6 +174,87 @@ describe('AppServerLanguageModel', () => {
     });
   });
 
+  it('maps top-level reasoning option to turn effort', async () => {
+    const client = new FakeClient();
+    const model = new AppServerLanguageModel({
+      id: 'gpt-5.3-codex',
+      client: client as never,
+    });
+
+    await model.doGenerate({
+      prompt: [{ role: 'user', content: 'Say hello' }] as never,
+      reasoning: 'high',
+    });
+
+    expect((client.turnStartCalls[0] as TurnStartParams).effort).toBe('high');
+  });
+
+  it('prefers providerOptions effort over top-level reasoning', async () => {
+    const client = new FakeClient();
+    const model = new AppServerLanguageModel({
+      id: 'gpt-5.3-codex',
+      client: client as never,
+    });
+
+    await model.doGenerate({
+      prompt: [{ role: 'user', content: 'Say hello' }] as never,
+      reasoning: 'low',
+      providerOptions: { 'codex-app-server': { effort: 'xhigh' } },
+    });
+
+    expect((client.turnStartCalls[0] as TurnStartParams).effort).toBe('xhigh');
+  });
+
+  it('leaves configured effort untouched for provider-default reasoning', async () => {
+    const client = new FakeClient();
+    const model = new AppServerLanguageModel({
+      id: 'gpt-5.3-codex',
+      client: client as never,
+      settings: { effort: 'medium' },
+    });
+
+    await model.doGenerate({
+      prompt: [{ role: 'user', content: 'Say hello' }] as never,
+      reasoning: 'provider-default',
+    });
+
+    expect((client.turnStartCalls[0] as TurnStartParams).effort).toBe('medium');
+  });
+
+  it('leaves configured effort untouched when reasoning is undefined', async () => {
+    const client = new FakeClient();
+    const model = new AppServerLanguageModel({
+      id: 'gpt-5.3-codex',
+      client: client as never,
+      settings: { effort: 'minimal' },
+    });
+
+    await model.doGenerate({
+      prompt: [{ role: 'user', content: 'Say hello' }] as never,
+    });
+
+    expect((client.turnStartCalls[0] as TurnStartParams).effort).toBe('minimal');
+  });
+
+  it('warns and unsets effort for unmappable reasoning values', async () => {
+    const client = new FakeClient();
+    const model = new AppServerLanguageModel({
+      id: 'gpt-5.3-codex',
+      client: client as never,
+      settings: { effort: 'medium' },
+    });
+
+    const result = await model.doGenerate({
+      prompt: [{ role: 'user', content: 'Say hello' }] as never,
+      reasoning: 'ultra' as never,
+    });
+
+    expect((client.turnStartCalls[0] as TurnStartParams).effort).toBeUndefined();
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ type: 'unsupported', feature: 'reasoning' }),
+    );
+  });
+
   it('doGenerate keeps only the final completed text block when multiple are emitted', async () => {
     const client = new FakeClient();
     client.turnStartImpl = async (params) => {

--- a/src/__tests__/app-server-notification-router.test.ts
+++ b/src/__tests__/app-server-notification-router.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
-import type { LanguageModelV3StreamPart, LanguageModelV3Usage } from '@ai-sdk/provider';
+import type { LanguageModelV4StreamPart, LanguageModelV4Usage } from '@ai-sdk/provider';
 import { AppServerStreamEmitter } from '../app-server/stream/emitter.js';
 import { AppServerNotificationRouter } from '../app-server/stream/router.js';
 
 class FakeClient extends EventEmitter {}
 
 function createCapture() {
-  const parts: LanguageModelV3StreamPart[] = [];
+  const parts: LanguageModelV4StreamPart[] = [];
   const controller = {
-    enqueue: (part: LanguageModelV3StreamPart) => parts.push(part),
+    enqueue: (part: LanguageModelV4StreamPart) => parts.push(part),
     close: vi.fn(),
     error: vi.fn(),
-  } as unknown as ReadableStreamDefaultController<LanguageModelV3StreamPart>;
+  } as unknown as ReadableStreamDefaultController<LanguageModelV4StreamPart>;
 
   return { parts, controller };
 }
@@ -27,7 +27,7 @@ describe('AppServerNotificationRouter', () => {
       includeRawChunks: true,
     });
 
-    let usage: LanguageModelV3Usage | undefined;
+    let usage: LanguageModelV4Usage | undefined;
     let completedTurnId: string | undefined;
     const router = new AppServerNotificationRouter({
       client: client as never,
@@ -374,7 +374,7 @@ describe('AppServerNotificationRouter', () => {
       threadId: 'thr_usage',
     });
 
-    let usage: LanguageModelV3Usage | undefined;
+    let usage: LanguageModelV4Usage | undefined;
     const router = new AppServerNotificationRouter({
       client: client as never,
       emitter,

--- a/src/__tests__/app-server-notification-router.test.ts
+++ b/src/__tests__/app-server-notification-router.test.ts
@@ -595,4 +595,213 @@ describe('AppServerNotificationRouter', () => {
       ['item/commandExecution/requestApproval', 'item/fileChange/requestApproval'].sort(),
     );
   });
+
+  it('maps dynamicToolCall items to provider-executed dynamic tool parts like mcpToolCall', () => {
+    const client = new FakeClient();
+    const { parts, controller } = createCapture();
+    const emitter = new AppServerStreamEmitter(controller, {
+      modelId: 'gpt-5.3-codex',
+      threadId: 'thr_dynamic',
+    });
+
+    const router = new AppServerNotificationRouter({
+      client: client as never,
+      emitter,
+      threadId: 'thr_dynamic',
+      onUsage: () => undefined,
+      onTurnCompleted: () => undefined,
+      onError: () => undefined,
+    });
+
+    router.setTurnId('turn_dynamic_1');
+    router.subscribe();
+
+    client.emit('notification', 'item/started', {
+      threadId: 'thr_dynamic',
+      turnId: 'turn_dynamic_1',
+      item: {
+        type: 'dynamicToolCall',
+        id: 'item_dyn_1',
+        namespace: 'search',
+        tool: 'lookup',
+        arguments: { q: 'hello' },
+        status: 'inProgress',
+        contentItems: null,
+        success: null,
+        durationMs: null,
+      },
+    });
+    client.emit('notification', 'item/completed', {
+      threadId: 'thr_dynamic',
+      turnId: 'turn_dynamic_1',
+      item: {
+        type: 'dynamicToolCall',
+        id: 'item_dyn_1',
+        namespace: 'search',
+        tool: 'lookup',
+        arguments: { q: 'hello' },
+        status: 'completed',
+        contentItems: [],
+        success: true,
+        durationMs: 8,
+      },
+    });
+
+    router.unsubscribe();
+
+    expect(parts.map((part) => part.type)).toEqual([
+      'tool-input-start',
+      'tool-input-delta',
+      'tool-input-end',
+      'tool-call',
+      'tool-result',
+    ]);
+
+    const toolCall = parts.find((part) => part.type === 'tool-call');
+    expect(toolCall).toMatchObject({
+      toolCallId: 'item_dyn_1',
+      toolName: 'search__lookup',
+      providerExecuted: true,
+      dynamic: true,
+    });
+
+    const toolResult = parts.find((part) => part.type === 'tool-result');
+    expect(toolResult).toMatchObject({
+      toolCallId: 'item_dyn_1',
+      toolName: 'search__lookup',
+      dynamic: true,
+    });
+    expect(toolResult).not.toMatchObject({ isError: true });
+  });
+
+  it('marks failed dynamicToolCall results as errors and uses bare tool name without namespace', () => {
+    const client = new FakeClient();
+    const { parts, controller } = createCapture();
+    const emitter = new AppServerStreamEmitter(controller, {
+      modelId: 'gpt-5.3-codex',
+      threadId: 'thr_dynamic_fail',
+    });
+
+    const router = new AppServerNotificationRouter({
+      client: client as never,
+      emitter,
+      threadId: 'thr_dynamic_fail',
+      onUsage: () => undefined,
+      onTurnCompleted: () => undefined,
+      onError: () => undefined,
+    });
+
+    router.setTurnId('turn_dynamic_fail_1');
+    router.subscribe();
+
+    client.emit('notification', 'item/started', {
+      threadId: 'thr_dynamic_fail',
+      turnId: 'turn_dynamic_fail_1',
+      item: {
+        type: 'dynamicToolCall',
+        id: 'item_dyn_fail_1',
+        namespace: null,
+        tool: 'lookup',
+        arguments: {},
+        status: 'inProgress',
+        contentItems: null,
+        success: null,
+        durationMs: null,
+      },
+    });
+    client.emit('notification', 'item/completed', {
+      threadId: 'thr_dynamic_fail',
+      turnId: 'turn_dynamic_fail_1',
+      item: {
+        type: 'dynamicToolCall',
+        id: 'item_dyn_fail_1',
+        namespace: null,
+        tool: 'lookup',
+        arguments: {},
+        status: 'failed',
+        contentItems: null,
+        success: false,
+        durationMs: 3,
+      },
+    });
+
+    router.unsubscribe();
+
+    const toolCall = parts.find((part) => part.type === 'tool-call');
+    expect(toolCall).toMatchObject({
+      toolCallId: 'item_dyn_fail_1',
+      toolName: 'lookup',
+      providerExecuted: true,
+      dynamic: true,
+    });
+
+    const toolResult = parts.find((part) => part.type === 'tool-result');
+    expect(toolResult).toMatchObject({
+      toolCallId: 'item_dyn_fail_1',
+      toolName: 'lookup',
+      dynamic: true,
+      isError: true,
+    });
+  });
+
+  it('ignores unknown item types but still completes the turn', () => {
+    const client = new FakeClient();
+    const { parts, controller } = createCapture();
+    const emitter = new AppServerStreamEmitter(controller, {
+      modelId: 'gpt-5.3-codex',
+      threadId: 'thr_future',
+    });
+
+    let completedTurnId: string | undefined;
+    const router = new AppServerNotificationRouter({
+      client: client as never,
+      emitter,
+      threadId: 'thr_future',
+      onUsage: () => undefined,
+      onTurnCompleted: (turn) => {
+        completedTurnId = turn.id;
+      },
+      onError: () => {
+        throw new Error('unexpected error callback');
+      },
+    });
+
+    router.setTurnId('turn_future_1');
+    router.subscribe();
+
+    const futureWidget = {
+      type: 'futureWidget',
+      id: 'item_future_1',
+      widgetPayload: { nested: true },
+    };
+
+    client.emit('notification', 'item/started', {
+      threadId: 'thr_future',
+      turnId: 'turn_future_1',
+      item: futureWidget,
+    });
+    client.emit('notification', 'item/completed', {
+      threadId: 'thr_future',
+      turnId: 'turn_future_1',
+      item: futureWidget,
+    });
+    client.emit('notification', 'turn/completed', {
+      threadId: 'thr_future',
+      turn: {
+        id: 'turn_future_1',
+        items: [futureWidget],
+        status: 'failed',
+        error: {
+          message: 'future failure',
+          codexErrorInfo: { futureVariant: { detail: 'x' } },
+          additionalDetails: null,
+        },
+      },
+    });
+
+    router.unsubscribe();
+
+    expect(parts.filter((part) => part.type !== 'raw')).toHaveLength(0);
+    expect(completedTurnId).toBe('turn_future_1');
+  });
 });

--- a/src/__tests__/app-server-protocol-compat.test.ts
+++ b/src/__tests__/app-server-protocol-compat.test.ts
@@ -100,3 +100,260 @@ describe('app-server protocol validators', () => {
     expect(invalid.success).toBe(false);
   });
 });
+
+describe('codex 0.142.5 protocol shapes', () => {
+  it('parses a turn/completed payload with 0.142.5 turn metadata and item variants', () => {
+    const schema = incomingNotificationSchemas['turn/completed'];
+    expect(schema).toBeDefined();
+    if (!schema) return;
+
+    const result = schema.safeParse({
+      threadId: 'thr_1',
+      turn: {
+        id: 'turn_1',
+        itemsView: 'full',
+        status: 'completed',
+        error: null,
+        startedAt: 1783384428,
+        completedAt: 1783384500,
+        durationMs: 72000,
+        items: [
+          {
+            type: 'userMessage',
+            id: 'item_user_1',
+            clientId: null,
+            content: [
+              { type: 'text', text: 'hi', text_elements: [] },
+              { type: 'image', url: 'https://example.com/cat.png', detail: 'auto' },
+              { type: 'localImage', path: '/tmp/dog.png', detail: 'high' },
+            ],
+          },
+          {
+            type: 'agentMessage',
+            id: 'item_msg_1',
+            text: 'Hello',
+            phase: 'final_answer',
+            memoryCitation: null,
+          },
+          {
+            type: 'commandExecution',
+            id: 'item_cmd_1',
+            command: 'ls',
+            cwd: '/tmp',
+            processId: null,
+            source: 'agent',
+            status: 'completed',
+            commandActions: [],
+            aggregatedOutput: 'ok',
+            exitCode: 0,
+            durationMs: 12,
+          },
+          {
+            type: 'mcpToolCall',
+            id: 'item_mcp_1',
+            server: 'everything',
+            tool: 'echo',
+            status: 'completed',
+            arguments: { message: 'ping' },
+            appContext: null,
+            pluginId: null,
+            result: { content: [] },
+            error: null,
+            durationMs: 20,
+          },
+          {
+            type: 'dynamicToolCall',
+            id: 'item_dyn_1',
+            namespace: null,
+            tool: 'search',
+            arguments: { q: 'hello' },
+            status: 'completed',
+            contentItems: [],
+            success: true,
+            durationMs: 5,
+          },
+          { type: 'hookPrompt', id: 'item_hook_1', fragments: [] },
+          {
+            type: 'subAgentActivity',
+            id: 'item_sub_1',
+            kind: 'started',
+            agentThreadId: 'thr_child',
+            agentPath: 'explorer',
+          },
+          { type: 'sleep', id: 'item_sleep_1', durationMs: 1000 },
+          {
+            type: 'imageGeneration',
+            id: 'item_img_1',
+            status: 'completed',
+            revisedPrompt: null,
+            result: 'done',
+            savedPath: '/tmp/out.png',
+          },
+          {
+            type: 'collabAgentToolCall',
+            id: 'item_collab_1',
+            tool: 'spawnAgent',
+            status: 'completed',
+            senderThreadId: 'thr_1',
+            receiverThreadIds: ['thr_child'],
+            prompt: 'do work',
+            model: 'gpt-5.5',
+            reasoningEffort: 'high',
+            agentsStates: {},
+          },
+        ],
+      },
+    });
+
+    expect(result.success, JSON.stringify(!result.success && result.error.issues)).toBe(true);
+  });
+
+  it('parses 0.142.5 codexErrorInfo variants', () => {
+    const schema = incomingNotificationSchemas['error'];
+    expect(schema).toBeDefined();
+    if (!schema) return;
+
+    for (const codexErrorInfo of [
+      'cyberPolicy',
+      { activeTurnNotSteerable: { turnKind: 'review' } },
+    ]) {
+      const result = schema.safeParse({
+        threadId: 'thr_1',
+        turnId: 'turn_1',
+        willRetry: false,
+        error: { message: 'boom', codexErrorInfo, additionalDetails: null },
+      });
+      expect(result.success, JSON.stringify(codexErrorInfo)).toBe(true);
+    }
+  });
+
+  it('parses item lifecycle and reasoning delta notifications with 0.142.5 fields', () => {
+    const cases: Array<{ method: string; params: Record<string, unknown> }> = [
+      {
+        method: 'item/started',
+        params: {
+          threadId: 'thr_1',
+          turnId: 'turn_1',
+          startedAtMs: 1783384428000,
+          item: { type: 'plan', id: 'item_plan_1', text: 'plan' },
+        },
+      },
+      {
+        method: 'item/completed',
+        params: {
+          threadId: 'thr_1',
+          turnId: 'turn_1',
+          completedAtMs: 1783384429000,
+          item: {
+            type: 'reasoning',
+            id: 'item_reason_1',
+            summary: ['s'],
+            content: ['c'],
+          },
+        },
+      },
+      {
+        method: 'item/reasoning/textDelta',
+        params: {
+          threadId: 'thr_1',
+          turnId: 'turn_1',
+          itemId: 'item_reason_1',
+          delta: 'thinking',
+          contentIndex: 0,
+        },
+      },
+      {
+        method: 'item/reasoning/summaryTextDelta',
+        params: {
+          threadId: 'thr_1',
+          turnId: 'turn_1',
+          itemId: 'item_reason_1',
+          delta: 'summary',
+          summaryIndex: 1,
+        },
+      },
+    ];
+
+    for (const { method, params } of cases) {
+      const schema = incomingNotificationSchemas[method];
+      expect(schema, `missing schema for ${method}`).toBeDefined();
+      if (!schema) continue;
+      const result = schema.safeParse(params);
+      expect(result.success, method).toBe(true);
+    }
+  });
+
+  it('parses 0.142.5 server requests', () => {
+    const requests = [
+      {
+        id: 201,
+        method: 'item/commandExecution/requestApproval',
+        params: {
+          threadId: 'thr_1',
+          turnId: 'turn_1',
+          itemId: 'item_cmd_1',
+          startedAtMs: 1783384428000,
+          approvalId: null,
+          environmentId: null,
+          command: 'npm test',
+          cwd: '/tmp/project',
+          commandActions: [],
+          availableDecisions: ['accept', 'decline'],
+          proposedNetworkPolicyAmendments: null,
+        },
+      },
+      {
+        id: 202,
+        method: 'item/fileChange/requestApproval',
+        params: {
+          threadId: 'thr_1',
+          turnId: 'turn_1',
+          itemId: 'item_file_1',
+          startedAtMs: 1783384428000,
+          reason: null,
+        },
+      },
+      {
+        id: 203,
+        method: 'item/tool/requestUserInput',
+        params: {
+          threadId: 'thr_1',
+          turnId: 'turn_1',
+          itemId: 'item_tool_1',
+          questions: [],
+          autoResolutionMs: null,
+        },
+      },
+      {
+        id: 204,
+        method: 'item/tool/call',
+        params: {
+          threadId: 'thr_1',
+          turnId: 'turn_1',
+          callId: 'call_1',
+          namespace: null,
+          tool: 'search',
+          arguments: { q: 'hello' },
+        },
+      },
+      {
+        id: 205,
+        method: 'mcpServer/elicitation/request',
+        params: {
+          threadId: 'thr_1',
+          turnId: null,
+          serverName: 'everything',
+          mode: 'openai/form',
+          _meta: null,
+          message: 'Fill the form',
+          requestedSchema: { type: 'object', properties: {} },
+        },
+      },
+    ];
+
+    for (const request of requests) {
+      const result = serverRequestSchema.safeParse(request);
+      expect(result.success, request.method).toBe(true);
+    }
+  });
+});

--- a/src/__tests__/app-server-protocol-compat.test.ts
+++ b/src/__tests__/app-server-protocol-compat.test.ts
@@ -78,12 +78,12 @@ describe('app-server protocol validators', () => {
     expect(serverRequestSchema.safeParse(request).success).toBe(true);
   });
 
-  it('rejects invalid codexErrorInfo payloads', () => {
+  it('tolerates unknown codexErrorInfo variants but rejects non-string/non-object payloads', () => {
     const schema = incomingNotificationSchemas['turn/completed'];
     expect(schema).toBeDefined();
     if (!schema) return;
 
-    const invalid = schema.safeParse({
+    const turnWithErrorInfo = (codexErrorInfo: unknown) => ({
       threadId: 'thr_1',
       turn: {
         id: 'turn_1',
@@ -91,13 +91,89 @@ describe('app-server protocol validators', () => {
         status: 'failed',
         error: {
           message: 'boom',
-          codexErrorInfo: { unsupported: true },
+          codexErrorInfo,
           additionalDetails: null,
         },
       },
     });
 
+    // Unknown future variants must validate; dropping the notification would
+    // hang the stream (turn/completed is the only completion signal).
+    expect(schema.safeParse(turnWithErrorInfo({ unsupported: true })).success).toBe(true);
+    expect(schema.safeParse(turnWithErrorInfo('futureErrorCode')).success).toBe(true);
+
+    // Structurally invalid payloads are still rejected.
+    expect(schema.safeParse(turnWithErrorInfo(42)).success).toBe(false);
+    expect(schema.safeParse(turnWithErrorInfo(['other'])).success).toBe(false);
+  });
+
+  it('tolerates unknown thread item types in turn/completed and item lifecycle notifications', () => {
+    const turnCompletedSchema = incomingNotificationSchemas['turn/completed'];
+    expect(turnCompletedSchema).toBeDefined();
+    if (!turnCompletedSchema) return;
+
+    const futureWidget = {
+      type: 'futureWidget',
+      id: 'item_future_1',
+      widgetPayload: { nested: true },
+    };
+
+    const completed = turnCompletedSchema.safeParse({
+      threadId: 'thr_1',
+      turn: {
+        id: 'turn_1',
+        items: [futureWidget],
+        status: 'completed',
+        error: null,
+      },
+    });
+    expect(completed.success, JSON.stringify(!completed.success && completed.error.issues)).toBe(
+      true,
+    );
+
+    for (const method of ['item/started', 'item/completed']) {
+      const schema = incomingNotificationSchemas[method];
+      expect(schema, method).toBeDefined();
+      const result = schema?.safeParse({
+        threadId: 'thr_1',
+        turnId: 'turn_1',
+        item: futureWidget,
+      });
+      expect(result?.success, method).toBe(true);
+    }
+
+    // Items missing a string `type` are still rejected — routing requires it.
+    const invalid = turnCompletedSchema.safeParse({
+      threadId: 'thr_1',
+      turn: {
+        id: 'turn_1',
+        items: [{ id: 'item_untyped', payload: 'x' }],
+        status: 'completed',
+        error: null,
+      },
+    });
     expect(invalid.success).toBe(false);
+  });
+
+  it('validates a failed turn combining a fabricated item type and errorInfo variant', () => {
+    const schema = incomingNotificationSchemas['turn/completed'];
+    expect(schema).toBeDefined();
+    if (!schema) return;
+
+    const result = schema.safeParse({
+      threadId: 'thr_1',
+      turn: {
+        id: 'turn_1',
+        items: [{ type: 'futureWidget', id: 'item_future_1' }],
+        status: 'failed',
+        error: {
+          message: 'future failure',
+          codexErrorInfo: { futureVariant: { detail: 'x' } },
+          additionalDetails: null,
+        },
+      },
+    });
+    expect(result.success, JSON.stringify(!result.success && result.error.issues)).toBe(true);
   });
 });
 

--- a/src/__tests__/app-server-protocol-compat.test.ts
+++ b/src/__tests__/app-server-protocol-compat.test.ts
@@ -107,6 +107,38 @@ describe('app-server protocol validators', () => {
     expect(schema.safeParse(turnWithErrorInfo(['other'])).success).toBe(false);
   });
 
+  it('tolerates future turn status and missing nullable error details', () => {
+    const schema = incomingNotificationSchemas['turn/completed'];
+    expect(schema).toBeDefined();
+    if (!schema) return;
+
+    expect(
+      schema.safeParse({
+        threadId: 'thr_1',
+        turn: {
+          id: 'turn_1',
+          items: [],
+          status: 'futureStatus',
+        },
+      }).success,
+    ).toBe(true);
+
+    expect(
+      schema.safeParse({
+        threadId: 'thr_1',
+        turn: {
+          id: 'turn_1',
+          items: [],
+          status: 'failed',
+          error: {
+            message: 'future failure',
+            codexErrorInfo: { futureError: { nested: true } },
+          },
+        },
+      }).success,
+    ).toBe(true);
+  });
+
   it('tolerates unknown thread item types in turn/completed and item lifecycle notifications', () => {
     const turnCompletedSchema = incomingNotificationSchemas['turn/completed'];
     expect(turnCompletedSchema).toBeDefined();

--- a/src/__tests__/app-server-provider.test.ts
+++ b/src/__tests__/app-server-provider.test.ts
@@ -9,12 +9,20 @@ import { createSdkMcpServer, tool } from '../tools/index.js';
 describe('createCodexAppServer', () => {
   it('creates language model instances', () => {
     const provider = createCodexAppServer({
-      defaultSettings: { minCodexVersion: '0.130.0', personality: 'pragmatic' },
+      defaultSettings: { minCodexVersion: '0.142.5', personality: 'pragmatic' },
     });
 
     const model: any = provider('gpt-5.3-codex');
     expect(model.provider).toBe('codex-app-server');
     expect(model.modelId).toBe('gpt-5.3-codex');
+  });
+
+  it('exposes specification version v4 and empty supportedUrls on models', () => {
+    const provider = createCodexAppServer();
+    expect(provider.specificationVersion).toBe('v4');
+    const model = provider('gpt-5.5');
+    expect(model.specificationVersion).toBe('v4');
+    expect(model.supportedUrls).toEqual({});
   });
 
   it('exposes close()', async () => {
@@ -97,7 +105,7 @@ describe('createCodexAppServer', () => {
   it('uses a distinct RPC client when per-model transport settings differ', async () => {
     const provider = createCodexAppServer({
       defaultSettings: {
-        minCodexVersion: '0.130.0',
+        minCodexVersion: '0.142.5',
         requestTimeoutMs: 10_000,
       },
     });
@@ -124,7 +132,7 @@ describe('createCodexAppServer', () => {
   it('reuses RPC client when only non-transport model settings differ', async () => {
     const provider = createCodexAppServer({
       defaultSettings: {
-        minCodexVersion: '0.130.0',
+        minCodexVersion: '0.142.5',
       },
     });
 
@@ -143,7 +151,7 @@ describe('createCodexAppServer', () => {
   it('reuses persistent model instances for identical model + settings', async () => {
     const provider = createCodexAppServer({
       defaultSettings: {
-        minCodexVersion: '0.130.0',
+        minCodexVersion: '0.142.5',
       },
     });
 
@@ -175,7 +183,7 @@ describe('createCodexAppServer', () => {
 
     const provider = createCodexAppServer({
       defaultSettings: {
-        minCodexVersion: '0.130.0',
+        minCodexVersion: '0.142.5',
         threadMode: 'persistent',
         mcpServers: {
           math: sdkServer,
@@ -219,7 +227,7 @@ describe('createCodexAppServer', () => {
     };
 
     const provider = createCodexAppServer({
-      defaultSettings: { minCodexVersion: '0.130.0' },
+      defaultSettings: { minCodexVersion: '0.142.5' },
     });
 
     const first = provider('gpt-5.3-codex', createSettings());
@@ -253,7 +261,7 @@ describe('createCodexAppServer', () => {
     };
 
     const provider = createCodexAppServer({
-      defaultSettings: { minCodexVersion: '0.130.0' },
+      defaultSettings: { minCodexVersion: '0.142.5' },
     });
 
     const first = provider('gpt-5.3-codex', createSettings());
@@ -285,7 +293,7 @@ describe('createCodexAppServer', () => {
     };
 
     const provider = createCodexAppServer({
-      defaultSettings: { minCodexVersion: '0.130.0' },
+      defaultSettings: { minCodexVersion: '0.142.5' },
     });
 
     const first = provider('gpt-5.3-codex', createSettings(0));
@@ -311,7 +319,7 @@ describe('createCodexAppServer', () => {
     });
 
     const provider = createCodexAppServer({
-      defaultSettings: { minCodexVersion: '0.130.0' },
+      defaultSettings: { minCodexVersion: '0.142.5' },
     });
 
     const first = provider('gpt-5.3-codex', {
@@ -341,7 +349,7 @@ describe('createCodexAppServer', () => {
   it('retains persistent model cache entries until provider.close()', async () => {
     const provider = createCodexAppServer({
       defaultSettings: {
-        minCodexVersion: '0.130.0',
+        minCodexVersion: '0.142.5',
       },
     });
 

--- a/src/__tests__/app-server-rpc-client.test.ts
+++ b/src/__tests__/app-server-rpc-client.test.ts
@@ -77,7 +77,7 @@ function createMockProcess(
           `${JSON.stringify({
             id: message.id,
             result: {
-              userAgent: options.userAgent ?? 'codex-cli 0.130.0',
+              userAgent: options.userAgent ?? 'codex-cli 0.142.5',
               capabilities: options.initializeCapabilities ?? null,
             },
           })}\n`,
@@ -863,21 +863,21 @@ describe('AppServerRpcClient', () => {
   });
 
   it('enforces min version against prerelease builds', async () => {
-    const { child } = createMockProcess({ userAgent: 'codex-cli 0.130.0-alpha.17' });
+    const { child } = createMockProcess({ userAgent: 'codex-cli 0.142.5-alpha.17' });
     setSpawnMock(() => child);
 
     const client = new AppServerRpcClient({
-      settings: { minCodexVersion: '0.130.0' },
+      settings: { minCodexVersion: '0.142.5' },
     });
 
     await expect(client.ensureReady()).rejects.toThrow(
-      "codex app-server version '0.130.0-alpha.17' is below required minimum '0.130.0'.",
+      "codex app-server version '0.142.5-alpha.17' is below required minimum '0.142.5'.",
     );
   });
 
   it('kills spawned process and recovers cleanly after initialization failure', async () => {
     const first = createMockProcess({ userAgent: 'codex-cli 0.104.9' });
-    const second = createMockProcess({ userAgent: 'codex-cli 0.130.0' });
+    const second = createMockProcess({ userAgent: 'codex-cli 0.142.5' });
     let spawns = 0;
     setSpawnMock(() => {
       spawns += 1;
@@ -885,11 +885,11 @@ describe('AppServerRpcClient', () => {
     });
 
     const client = new AppServerRpcClient({
-      settings: { minCodexVersion: '0.130.0' },
+      settings: { minCodexVersion: '0.142.5' },
     });
 
     await expect(client.ensureReady()).rejects.toThrow(
-      "codex app-server version '0.104.9' is below required minimum '0.130.0'.",
+      "codex app-server version '0.104.9' is below required minimum '0.142.5'.",
     );
     expect(first.child.kill).toHaveBeenCalledWith('SIGTERM');
 

--- a/src/__tests__/app-server-stream-emitter.test.ts
+++ b/src/__tests__/app-server-stream-emitter.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { LanguageModelV3StreamPart } from '@ai-sdk/provider';
+import type { LanguageModelV4StreamPart } from '@ai-sdk/provider';
 import { AppServerStreamEmitter } from '../app-server/stream/emitter.js';
 import { createEmptyCodexUsage } from '../shared-utils.js';
 
 function createCapture() {
-  const parts: LanguageModelV3StreamPart[] = [];
+  const parts: LanguageModelV4StreamPart[] = [];
   const controller = {
-    enqueue: (part: LanguageModelV3StreamPart) => parts.push(part),
+    enqueue: (part: LanguageModelV4StreamPart) => parts.push(part),
     close: vi.fn(),
     error: vi.fn(),
-  } as unknown as ReadableStreamDefaultController<LanguageModelV3StreamPart>;
+  } as unknown as ReadableStreamDefaultController<LanguageModelV4StreamPart>;
 
   return { parts, controller };
 }
@@ -193,7 +193,7 @@ describe('AppServerStreamEmitter', () => {
       error: vi.fn(() => {
         throw new Error('already errored');
       }),
-    } as unknown as ReadableStreamDefaultController<LanguageModelV3StreamPart>;
+    } as unknown as ReadableStreamDefaultController<LanguageModelV4StreamPart>;
 
     const emitter = new AppServerStreamEmitter(controller, {
       modelId: 'gpt-5.3-codex',

--- a/src/__tests__/app-server-turn-stream-controller.test.ts
+++ b/src/__tests__/app-server-turn-stream-controller.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
-import type { LanguageModelV3StreamPart } from '@ai-sdk/provider';
+import type { LanguageModelV4StreamPart } from '@ai-sdk/provider';
 import { TurnStreamController } from '../app-server/stream/turn-stream-controller.js';
 import type { TurnStartParams } from '../app-server/protocol/types.js';
 
@@ -73,12 +73,12 @@ class FakeClient extends EventEmitter {
 }
 
 function createCapture() {
-  const parts: LanguageModelV3StreamPart[] = [];
+  const parts: LanguageModelV4StreamPart[] = [];
   const controller = {
-    enqueue: (part: LanguageModelV3StreamPart) => parts.push(part),
+    enqueue: (part: LanguageModelV4StreamPart) => parts.push(part),
     close: vi.fn(),
     error: vi.fn(),
-  } as unknown as ReadableStreamDefaultController<LanguageModelV3StreamPart>;
+  } as unknown as ReadableStreamDefaultController<LanguageModelV4StreamPart>;
 
   return { parts, controller };
 }

--- a/src/__tests__/codex-cli-provider.test.ts
+++ b/src/__tests__/codex-cli-provider.test.ts
@@ -14,6 +14,7 @@ describe('createCodexCli', () => {
     expect(provider.specificationVersion).toBe('v4');
     const model = provider('gpt-5');
     expect(model.specificationVersion).toBe('v4');
+    expect(model.supportedUrls).toEqual({});
   });
 
   it('accepts addDirs in defaultSettings', () => {

--- a/src/__tests__/codex-cli-provider.test.ts
+++ b/src/__tests__/codex-cli-provider.test.ts
@@ -9,6 +9,13 @@ describe('createCodexCli', () => {
     expect(model.modelId).toBe('gpt-5');
   });
 
+  it('exposes specification version v4 on provider and models', () => {
+    const provider = createCodexCli();
+    expect(provider.specificationVersion).toBe('v4');
+    const model = provider('gpt-5');
+    expect(model.specificationVersion).toBe('v4');
+  });
+
   it('accepts addDirs in defaultSettings', () => {
     const provider = createCodexCli({
       defaultSettings: { addDirs: ['../shared', '/tmp/lib'] },

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -40,7 +40,7 @@ describe('errors', () => {
   it('unsupported feature helper is detected', () => {
     const err = new UnsupportedFeatureError({
       feature: 'model/list',
-      minCodexVersion: '0.130.0',
+      minCodexVersion: '0.142.5',
       serverVersion: '0.104.0',
     });
     expect(isUnsupportedFeatureError(err)).toBe(true);

--- a/src/__tests__/exec-language-model.test.ts
+++ b/src/__tests__/exec-language-model.test.ts
@@ -274,6 +274,131 @@ describe('ExecLanguageModel', () => {
     expect(finish?.finishReason).toEqual({ unified: 'stop', raw: undefined });
   });
 
+  it('reassembles a JSONL event split across two stdout data chunks', async () => {
+    const threadLine = JSON.stringify({ type: 'thread.started', thread_id: 'thread-split' }) + '\n';
+    const itemLine =
+      JSON.stringify({
+        type: 'item.completed',
+        item: { item_type: 'assistant_message', text: 'Hello Split' },
+      }) + '\n';
+    const turnLine =
+      JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 1 } }) +
+      '\n';
+    // Split mid-JSON so neither fragment alone is valid JSON
+    const splitAt = 40;
+    const itemPart1 = itemLine.slice(0, splitAt);
+    const itemPart2 = itemLine.slice(splitAt);
+
+    (childProc as any).__setSpawnMock((_cmd: string, _args: string[]) => {
+      const child = new EventEmitter() as any;
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+      child.stdin = new PassThrough();
+      child.kill = vi.fn();
+
+      // Force distinct stdout 'data' events with macrotask gaps between partial writes
+      setTimeout(() => {
+        child.stdout.write(threadLine);
+        setTimeout(() => {
+          child.stdout.write(itemPart1);
+          setTimeout(() => {
+            child.stdout.write(itemPart2);
+            setTimeout(() => {
+              child.stdout.write(turnLine);
+              child.stdout.end();
+              child.emit('close', 0);
+            }, 0);
+          }, 0);
+        }, 0);
+      }, 5);
+
+      return child;
+    });
+
+    const model = new ExecLanguageModel({
+      id: 'gpt-5',
+      settings: { allowNpx: true, color: 'never' },
+    });
+    const { stream } = await model.doStream({
+      prompt: [{ role: 'user', content: 'Say hi' }] as any,
+    });
+
+    const received: any[] = [];
+    const rs = stream as ReadableStream<any>;
+    const it = (rs as any)[Symbol.asyncIterator]();
+    for await (const part of it) received.push(part);
+
+    const types = received.map((p) => p.type);
+    expect(types).toContain('response-metadata');
+    expect(types).toContain('text-delta');
+    expect(types).toContain('finish');
+    const deltaPayload = received.find((p) => p.type === 'text-delta');
+    expect(deltaPayload?.delta).toBe('Hello Split');
+    const finish = received.find((p) => p.type === 'finish');
+    expect(finish?.usage).toMatchObject({
+      inputTokens: { total: 1 },
+      outputTokens: { total: 1 },
+    });
+  });
+
+  it('flushes a final JSONL line delivered without a trailing newline before close', async () => {
+    // The final item.completed event is split mid-JSON across two data chunks, and the
+    // completing fragment has no trailing newline. Neither fragment alone is valid JSON,
+    // and there is no later data event or newline to trigger processing — so the event
+    // can only be parsed via the close-time stdoutBuffer flush path.
+    const threadLine = JSON.stringify({ type: 'thread.started', thread_id: 'thread-noeol' }) + '\n';
+    const itemLine = JSON.stringify({
+      type: 'item.completed',
+      item: { item_type: 'assistant_message', text: 'Flushed Split' },
+    }); // intentionally no trailing \n
+    // Split mid-JSON so neither fragment alone is valid JSON
+    const splitAt = 40;
+    const itemPart1 = itemLine.slice(0, splitAt);
+    const itemPart2 = itemLine.slice(splitAt);
+
+    (childProc as any).__setSpawnMock((_cmd: string, _args: string[]) => {
+      const child = new EventEmitter() as any;
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+      child.stdin = new PassThrough();
+      child.kill = vi.fn();
+
+      // Force distinct stdout 'data' events; final fragment has no \n and close follows immediately
+      setTimeout(() => {
+        child.stdout.write(threadLine);
+        setTimeout(() => {
+          child.stdout.write(itemPart1);
+          setTimeout(() => {
+            child.stdout.write(itemPart2);
+            child.stdout.end();
+            child.emit('close', 0);
+          }, 0);
+        }, 0);
+      }, 5);
+
+      return child;
+    });
+
+    const model = new ExecLanguageModel({
+      id: 'gpt-5',
+      settings: { allowNpx: true, color: 'never' },
+    });
+    const { stream } = await model.doStream({
+      prompt: [{ role: 'user', content: 'Say hi' }] as any,
+    });
+
+    const received: any[] = [];
+    const rs = stream as ReadableStream<any>;
+    const it = (rs as any)[Symbol.asyncIterator]();
+    for await (const part of it) received.push(part);
+
+    const types = received.map((p) => p.type);
+    expect(types).toContain('text-delta');
+    expect(types).toContain('finish');
+    const deltaPayload = received.find((p) => p.type === 'text-delta');
+    expect(deltaPayload?.delta).toBe('Flushed Split');
+  });
+
   it('marks provider-executed exec tools dynamic for AI SDK UI streams', async () => {
     const lines = [
       JSON.stringify({ type: 'thread.started', thread_id: 'thread-tools-ui' }),

--- a/src/__tests__/exec-language-model.test.ts
+++ b/src/__tests__/exec-language-model.test.ts
@@ -921,9 +921,7 @@ describe('ExecLanguageModel', () => {
         item: { item_type: 'assistant_message', text: 'ok' },
       }),
     ];
-    const prompt = [
-      { role: 'user' as const, content: [{ type: 'text' as const, text: 'Hi' }] },
-    ];
+    const prompt = [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Hi' }] }];
 
     it('maps top-level reasoning to Codex effort and overrides constructor default', async () => {
       let argsCaptured: string[] = [];

--- a/src/__tests__/exec-language-model.test.ts
+++ b/src/__tests__/exec-language-model.test.ts
@@ -1003,6 +1003,28 @@ describe('ExecLanguageModel', () => {
       expect(warning).toBeDefined();
       expect(warning?.details).toContain("'ultra'");
     });
+
+    it('warns and keeps configured effort for unmappable top-level reasoning', async () => {
+      let argsCaptured: string[] = [];
+      mockableChildProc.__setSpawnMock((cmd: string, args: string[]) => {
+        argsCaptured = args;
+        return makeMockSpawn(reasoningLines, 0)(cmd, args);
+      });
+
+      const model = new ExecLanguageModel({
+        id: 'gpt-5',
+        settings: { allowNpx: true, color: 'never', reasoningEffort: 'medium' },
+      });
+      const unmappableReasoning = 'ultra' as unknown as LanguageModelV4CallOptions['reasoning'];
+      const res = await model.doGenerate({ prompt, reasoning: unmappableReasoning });
+
+      expect(argsCaptured).toContain('model_reasoning_effort=medium');
+      const warning = res.warnings.find(
+        (w): w is Extract<SharedV4Warning, { type: 'unsupported' }> =>
+          w.type === 'unsupported' && w.feature === 'reasoning',
+      );
+      expect(warning?.details).toContain("'ultra'; it will be ignored");
+    });
   });
 
   describe('Phase 2: providerOptions overrides', () => {

--- a/src/__tests__/exec-language-model.test.ts
+++ b/src/__tests__/exec-language-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { streamText } from 'ai';
 import { ExecLanguageModel } from '../exec-language-model.js';
+import type { LanguageModelV4CallOptions, SharedV4Warning } from '@ai-sdk/provider';
 import { PassThrough } from 'node:stream';
 import { EventEmitter } from 'node:events';
 import { writeFileSync, mkdtempSync, readFileSync, existsSync } from 'node:fs';
@@ -58,6 +59,11 @@ vi.mock('node:child_process', async () => {
 
 // Access the helper to swap mocks inside tests
 const childProc = await import('node:child_process');
+// The vi.mock factory above augments the module with __setSpawnMock, which the
+// node:child_process module type cannot express.
+const mockableChildProc = childProc as unknown as {
+  __setSpawnMock: (fn: (cmd: string, args: string[]) => unknown) => void;
+};
 
 describe('ExecLanguageModel', () => {
   beforeEach(() => {
@@ -904,6 +910,100 @@ describe('ExecLanguageModel', () => {
       expect(lastArgs).toContain('--full-auto');
       expect(lastArgs.join(' ')).not.toMatch(/approval_policy|sandbox_mode/);
       expect(lastArgs).toContain('model_reasoning_effort=medium');
+    });
+  });
+
+  describe('top-level reasoning call option', () => {
+    const reasoningLines = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-reasoning-option' }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { item_type: 'assistant_message', text: 'ok' },
+      }),
+    ];
+    const prompt = [
+      { role: 'user' as const, content: [{ type: 'text' as const, text: 'Hi' }] },
+    ];
+
+    it('maps top-level reasoning to Codex effort and overrides constructor default', async () => {
+      let argsCaptured: string[] = [];
+      mockableChildProc.__setSpawnMock((cmd: string, args: string[]) => {
+        argsCaptured = args;
+        return makeMockSpawn(reasoningLines, 0)(cmd, args);
+      });
+
+      const model = new ExecLanguageModel({
+        id: 'gpt-5',
+        settings: { allowNpx: true, color: 'never', reasoningEffort: 'low' },
+      });
+      await model.doGenerate({ prompt, reasoning: 'high' });
+
+      expect(argsCaptured).toContain('model_reasoning_effort=high');
+      expect(argsCaptured.join(' ')).not.toContain('model_reasoning_effort=low');
+    });
+
+    it('providerOptions reasoningEffort overrides top-level reasoning', async () => {
+      let argsCaptured: string[] = [];
+      mockableChildProc.__setSpawnMock((cmd: string, args: string[]) => {
+        argsCaptured = args;
+        return makeMockSpawn(reasoningLines, 0)(cmd, args);
+      });
+
+      const model = new ExecLanguageModel({
+        id: 'gpt-5',
+        settings: { allowNpx: true, color: 'never' },
+      });
+      await model.doGenerate({
+        prompt,
+        reasoning: 'low',
+        providerOptions: { 'codex-cli': { reasoningEffort: 'xhigh' } },
+      });
+
+      expect(argsCaptured).toContain('model_reasoning_effort=xhigh');
+      expect(argsCaptured.join(' ')).not.toContain('model_reasoning_effort=low');
+    });
+
+    it("leaves effort unset for reasoning: 'provider-default'", async () => {
+      let argsCaptured: string[] = [];
+      mockableChildProc.__setSpawnMock((cmd: string, args: string[]) => {
+        argsCaptured = args;
+        return makeMockSpawn(reasoningLines, 0)(cmd, args);
+      });
+
+      const model = new ExecLanguageModel({
+        id: 'gpt-5',
+        settings: { allowNpx: true, color: 'never' },
+      });
+      const res = await model.doGenerate({ prompt, reasoning: 'provider-default' });
+
+      expect(argsCaptured.join(' ')).not.toContain('model_reasoning_effort=');
+      expect(
+        res.warnings.filter((w) => w.type === 'unsupported' && w.feature === 'reasoning'),
+      ).toHaveLength(0);
+    });
+
+    it('warns and leaves effort unset for unmappable top-level reasoning', async () => {
+      let argsCaptured: string[] = [];
+      mockableChildProc.__setSpawnMock((cmd: string, args: string[]) => {
+        argsCaptured = args;
+        return makeMockSpawn(reasoningLines, 0)(cmd, args);
+      });
+
+      const model = new ExecLanguageModel({
+        id: 'gpt-5',
+        settings: { allowNpx: true, color: 'never' },
+      });
+      // Runtime forward-compat: a future reasoning level outside the v4 union.
+      const unmappableReasoning = 'ultra' as unknown as LanguageModelV4CallOptions['reasoning'];
+      const res = await model.doGenerate({ prompt, reasoning: unmappableReasoning });
+
+      expect(argsCaptured.join(' ')).not.toContain('model_reasoning_effort=');
+      const warning = res.warnings.find(
+        (w): w is Extract<SharedV4Warning, { type: 'unsupported' }> =>
+          w.type === 'unsupported' && w.feature === 'reasoning',
+      );
+      expect(warning).toBeDefined();
+      expect(warning?.details).toContain("'ultra'");
     });
   });
 

--- a/src/__tests__/exec-provider.test.ts
+++ b/src/__tests__/exec-provider.test.ts
@@ -14,6 +14,7 @@ describe('createCodexExec', () => {
     expect(provider.specificationVersion).toBe('v4');
     const model = provider('gpt-5');
     expect(model.specificationVersion).toBe('v4');
+    expect(model.supportedUrls).toEqual({});
   });
 
   it('accepts addDirs in defaultSettings', () => {

--- a/src/__tests__/exec-provider.test.ts
+++ b/src/__tests__/exec-provider.test.ts
@@ -9,6 +9,13 @@ describe('createCodexExec', () => {
     expect(model.modelId).toBe('gpt-5');
   });
 
+  it('exposes specification version v4 on provider and models', () => {
+    const provider = createCodexExec();
+    expect(provider.specificationVersion).toBe('v4');
+    const model = provider('gpt-5');
+    expect(model.specificationVersion).toBe('v4');
+  });
+
   it('accepts addDirs in defaultSettings', () => {
     const provider = createCodexExec({
       defaultSettings: { addDirs: ['../shared', '/tmp/lib'] },

--- a/src/__tests__/image-converter.test.ts
+++ b/src/__tests__/image-converter.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { toImageReference } from '../converters/image-converter.js';
 
 describe('image-converter', () => {
-  it('maps file part with binary data to local image reference', () => {
+  it('maps file part with tagged binary data to local image reference', () => {
     const result = toImageReference({
       type: 'file',
       mediaType: 'image/png',
-      data: Buffer.from([0x89, 0x50]),
+      data: { type: 'data', data: Uint8Array.from([0x89, 0x50]) },
     } as never);
 
     expect(result).toBeDefined();
@@ -16,21 +16,11 @@ describe('image-converter', () => {
     }
   });
 
-  it('maps file part with HTTP URL to remote image reference', () => {
-    const result = toImageReference({
-      type: 'file',
-      mediaType: 'image/png',
-      data: 'https://example.com/cat.png',
-    } as never);
-
-    expect(result).toEqual({ kind: 'remote', url: 'https://example.com/cat.png' });
-  });
-
-  it('maps file part with data URL string to local image reference', () => {
+  it('maps file part with tagged base64 string data to local image reference', () => {
     const result = toImageReference({
       type: 'file',
       mediaType: 'image/jpeg',
-      data: 'data:image/jpeg;base64,AAAA',
+      data: { type: 'data', data: 'AAAA' },
     } as never);
 
     expect(result).toEqual({
@@ -39,7 +29,96 @@ describe('image-converter', () => {
     });
   });
 
-  it('maps file part with ArrayBuffer to local image reference', () => {
+  it('maps file part with tagged HTTP URL to remote image reference', () => {
+    const result = toImageReference({
+      type: 'file',
+      mediaType: 'image/png',
+      data: { type: 'url', url: new URL('https://example.com/cat.png') },
+    } as never);
+
+    expect(result).toEqual({ kind: 'remote', url: 'https://example.com/cat.png' });
+  });
+
+  it('maps file part with tagged data: URL to local image reference', () => {
+    const result = toImageReference({
+      type: 'file',
+      mediaType: 'image/jpeg',
+      data: { type: 'url', url: new URL('data:image/jpeg;base64,AAAA') },
+    } as never);
+
+    expect(result).toEqual({
+      kind: 'local',
+      image: { data: 'data:image/jpeg;base64,AAAA', mimeType: 'image/jpeg' },
+    });
+  });
+
+  it('rejects tagged file:// URLs', () => {
+    const result = toImageReference({
+      type: 'file',
+      mediaType: 'image/png',
+      data: { type: 'url', url: new URL('file:///tmp/image.png') },
+    } as never);
+
+    expect(result).toEqual({
+      kind: 'unsupported',
+      warning: 'file:// image URLs are not supported.',
+    });
+  });
+
+  it('returns unsupported for tagged reference file data', () => {
+    const result = toImageReference({
+      type: 'file',
+      mediaType: 'image/png',
+      data: { type: 'reference', reference: { openai: 'file-123' } },
+    } as never);
+
+    expect(result).toEqual({
+      kind: 'unsupported',
+      warning: 'File reference data is not supported for images.',
+    });
+  });
+
+  it('returns unsupported for tagged inline text file data', () => {
+    const result = toImageReference({
+      type: 'file',
+      mediaType: 'image/png',
+      data: { type: 'text', text: 'not an image' },
+    } as never);
+
+    expect(result).toEqual({
+      kind: 'unsupported',
+      warning: 'Inline text file data is not supported for images.',
+    });
+  });
+
+  it('resolves top-level segment mediaType by sniffing tagged image bytes', () => {
+    const result = toImageReference({
+      type: 'file',
+      mediaType: 'image',
+      data: { type: 'data', data: Uint8Array.from([0x89, 0x50, 0x4e, 0x47]) },
+    } as never);
+
+    expect(result?.kind).toBe('local');
+    if (result?.kind === 'local') {
+      expect(result.image.mimeType).toBe('image/png');
+      expect(result.image.data.startsWith('data:image/png;base64,')).toBe(true);
+    }
+  });
+
+  it('maps legacy untagged Buffer file data to local image reference', () => {
+    const result = toImageReference({
+      type: 'file',
+      mediaType: 'image/png',
+      data: Buffer.from([0x89, 0x50]),
+    } as never);
+
+    expect(result?.kind).toBe('local');
+    if (result?.kind === 'local') {
+      expect(result.image.data.startsWith('data:image/png;base64,')).toBe(true);
+    }
+  });
+
+  it('maps legacy untagged ArrayBuffer file data to local image reference', () => {
     const bytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47]);
     const result = toImageReference({
       type: 'file',
@@ -53,17 +132,27 @@ describe('image-converter', () => {
     }
   });
 
-  it('maps file part with Uint8Array to local image reference', () => {
+  it('maps legacy untagged HTTP URL string to remote image reference', () => {
     const result = toImageReference({
       type: 'file',
-      mediaType: 'image/webp',
-      data: Uint8Array.from([0x52, 0x49, 0x46, 0x46]),
+      mediaType: 'image/png',
+      data: 'https://example.com/cat.png',
     } as never);
 
-    expect(result?.kind).toBe('local');
-    if (result?.kind === 'local') {
-      expect(result.image.data.startsWith('data:image/webp;base64,')).toBe(true);
-    }
+    expect(result).toEqual({ kind: 'remote', url: 'https://example.com/cat.png' });
+  });
+
+  it('rejects legacy untagged file:// URL strings', () => {
+    const result = toImageReference({
+      type: 'file',
+      mediaType: 'image/png',
+      data: 'file:///tmp/image.png',
+    } as never);
+
+    expect(result).toEqual({
+      kind: 'unsupported',
+      warning: 'file:// image URLs are not supported.',
+    });
   });
 
   it('maps compat image part URL to remote image reference', () => {
@@ -88,34 +177,11 @@ describe('image-converter', () => {
     });
   });
 
-  it('maps file part URL object with https protocol to remote image reference', () => {
-    const result = toImageReference({
-      type: 'file',
-      mediaType: 'image/png',
-      data: new URL('https://example.com/url-object.png'),
-    } as never);
-
-    expect(result).toEqual({ kind: 'remote', url: 'https://example.com/url-object.png' });
-  });
-
-  it('rejects file:// URL sources', () => {
-    const result = toImageReference({
-      type: 'file',
-      mediaType: 'image/png',
-      data: 'file:///tmp/image.png',
-    } as never);
-
-    expect(result).toEqual({
-      kind: 'unsupported',
-      warning: 'file:// image URLs are not supported.',
-    });
-  });
-
   it('returns unsupported for non-image media types', () => {
     const result = toImageReference({
       type: 'file',
       mediaType: 'application/pdf',
-      data: 'https://example.com/file.pdf',
+      data: { type: 'url', url: new URL('https://example.com/file.pdf') },
     } as never);
 
     expect(result?.kind).toBe('unsupported');

--- a/src/__tests__/image-utils.test.ts
+++ b/src/__tests__/image-utils.test.ts
@@ -68,7 +68,7 @@ describe('extractImageData', () => {
     });
   });
 
-  describe('AI SDK v6 file parts', () => {
+  describe('legacy untagged file parts', () => {
     it('handles image file part with Buffer data', () => {
       const buffer = Buffer.from([0x52, 0x49, 0x46, 0x46]); // RIFF
       const result = extractImageData({
@@ -89,6 +89,81 @@ describe('extractImageData', () => {
       });
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('AI SDK v4 tagged file data', () => {
+    it('handles tagged data variant with bytes', () => {
+      const result = extractImageData({
+        type: 'file',
+        mediaType: 'image/webp',
+        data: { type: 'data', data: Uint8Array.from([0x52, 0x49, 0x46, 0x46]) },
+      });
+
+      expect(result?.data).toMatch(/^data:image\/webp;base64,/);
+      expect(result?.mimeType).toBe('image/webp');
+    });
+
+    it('handles tagged data variant with base64 string', () => {
+      const result = extractImageData({
+        type: 'file',
+        mediaType: 'image/png',
+        data: { type: 'data', data: 'iVBORw0KGgo=' },
+      });
+
+      expect(result?.data).toBe('data:image/png;base64,iVBORw0KGgo=');
+      expect(result?.mimeType).toBe('image/png');
+    });
+
+    it('handles tagged url variant with data: URL', () => {
+      const result = extractImageData({
+        type: 'file',
+        mediaType: 'image/png',
+        data: { type: 'url', url: new URL('data:image/png;base64,iVBORw0KGgo=') },
+      });
+
+      expect(result?.data).toBe('data:image/png;base64,iVBORw0KGgo=');
+    });
+
+    it('returns null for tagged http url variant', () => {
+      const result = extractImageData({
+        type: 'file',
+        mediaType: 'image/png',
+        data: { type: 'url', url: new URL('https://example.com/image.png') },
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for tagged reference variant', () => {
+      const result = extractImageData({
+        type: 'file',
+        mediaType: 'image/png',
+        data: { type: 'reference', reference: { openai: 'file-123' } },
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for tagged text variant', () => {
+      const result = extractImageData({
+        type: 'file',
+        mediaType: 'image/png',
+        data: { type: 'text', text: 'not image bytes' },
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('detects full media type from top-level segment mediaType', () => {
+      const result = extractImageData({
+        type: 'file',
+        mediaType: 'image',
+        data: { type: 'data', data: Uint8Array.from([0x89, 0x50, 0x4e, 0x47]) },
+      });
+
+      expect(result?.mimeType).toBe('image/png');
+      expect(result?.data).toMatch(/^data:image\/png;base64,/);
     });
   });
 

--- a/src/__tests__/message-mapper.test.ts
+++ b/src/__tests__/message-mapper.test.ts
@@ -170,7 +170,7 @@ describe('mapMessagesToPrompt', () => {
       expect(images[0]?.data).toMatch(/^data:image\/png;base64,/);
     });
 
-    it('handles AI SDK v6 file parts for image input', () => {
+    it('handles legacy untagged file parts for image input', () => {
       const buffer = Buffer.from([0x52, 0x49, 0x46, 0x46]); // RIFF
       const { images } = mapMessagesToPrompt([
         {
@@ -181,6 +181,26 @@ describe('mapMessagesToPrompt', () => {
           ],
         },
       ] as any);
+
+      expect(images).toHaveLength(1);
+      expect(images[0]?.data).toMatch(/^data:image\/webp;base64,/);
+      expect(images[0]?.mimeType).toBe('image/webp');
+    });
+
+    it('handles AI SDK v4 tagged file parts for image input', () => {
+      const { images } = mapMessagesToPrompt([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Tagged file part image' },
+            {
+              type: 'file',
+              mediaType: 'image/webp',
+              data: { type: 'data', data: Uint8Array.from([0x52, 0x49, 0x46, 0x46]) },
+            },
+          ],
+        },
+      ] as never);
 
       expect(images).toHaveLength(1);
       expect(images[0]?.data).toMatch(/^data:image\/webp;base64,/);

--- a/src/__tests__/prompt-converter.test.ts
+++ b/src/__tests__/prompt-converter.test.ts
@@ -418,8 +418,7 @@ describe('prompt-converter', () => {
     expect(
       converted.warnings.some(
         (warning) =>
-          warning.type === 'unsupported' &&
-          warning.feature === 'prompt.assistant.reasoning-file',
+          warning.type === 'unsupported' && warning.feature === 'prompt.assistant.reasoning-file',
       ),
     ).toBe(true);
   });

--- a/src/__tests__/prompt-converter.test.ts
+++ b/src/__tests__/prompt-converter.test.ts
@@ -12,7 +12,7 @@ describe('prompt-converter', () => {
           role: 'user',
           content: [
             { type: 'text', text: 'User text' },
-            { type: 'file', mediaType: 'image/png', data: 'data:image/png;base64,AAAA' },
+            { type: 'file', mediaType: 'image/png', data: { type: 'data', data: 'AAAA' } },
           ],
         },
         {
@@ -70,7 +70,7 @@ describe('prompt-converter', () => {
           role: 'user',
           content: [
             { type: 'text', text: 'newer' },
-            { type: 'file', mediaType: 'image/png', data: 'data:image/png;base64,BBBB' },
+            { type: 'file', mediaType: 'image/png', data: { type: 'data', data: 'BBBB' } },
           ],
         },
       ] as never,
@@ -94,7 +94,11 @@ describe('prompt-converter', () => {
           role: 'user',
           content: [
             { type: 'text', text: 'look' },
-            { type: 'file', mediaType: 'image/webp', data: 'https://example.com/cat.webp' },
+            {
+              type: 'file',
+              mediaType: 'image/webp',
+              data: { type: 'url', url: new URL('https://example.com/cat.webp') },
+            },
             { type: 'image', image: 'https://example.com/dog.png' },
           ],
         },
@@ -118,7 +122,7 @@ describe('prompt-converter', () => {
             {
               type: 'file',
               mediaType: 'application/pdf',
-              data: 'data:application/pdf;base64,QQ==',
+              data: { type: 'data', data: 'QQ==' },
             },
           ],
         },
@@ -235,7 +239,7 @@ describe('prompt-converter', () => {
           role: 'user',
           content: [
             { type: 'text', text: 'Please inspect' },
-            { type: 'file', mediaType: 'image/png', data: 'data:image/png;base64,AAAA' },
+            { type: 'file', mediaType: 'image/png', data: { type: 'data', data: 'AAAA' } },
             { type: 'image', image: 'https://example.com/remote.jpg' },
           ],
         },
@@ -288,5 +292,135 @@ describe('prompt-converter', () => {
     });
 
     expect(converted.text).toBe('');
+  });
+
+  it('handles all four tagged file data variants in user content', () => {
+    const converted = convertPromptToCodexInput({
+      mode: 'stateless',
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'variants' },
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              data: { type: 'data', data: Uint8Array.from([0x89, 0x50, 0x4e, 0x47]) },
+            },
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              data: { type: 'url', url: new URL('https://example.com/a.png') },
+            },
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              data: { type: 'reference', reference: { openai: 'file-123' } },
+            },
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              data: { type: 'text', text: 'inline document' },
+            },
+          ],
+        },
+      ] as never,
+    });
+
+    expect(converted.localImages).toHaveLength(1);
+    expect(converted.localImages[0]?.data.startsWith('data:image/png;base64,')).toBe(true);
+    expect(converted.remoteImageUrls).toEqual(['https://example.com/a.png']);
+    expect(
+      converted.warnings.some(
+        (warning) =>
+          warning.type === 'unsupported' &&
+          warning.feature === 'prompt.user.file' &&
+          warning.details.includes('reference'),
+      ),
+    ).toBe(true);
+    expect(
+      converted.warnings.some(
+        (warning) =>
+          warning.type === 'unsupported' &&
+          warning.feature === 'prompt.user.file' &&
+          warning.details.includes('Inline text file data'),
+      ),
+    ).toBe(true);
+  });
+
+  it('resolves top-level segment mediaType by sniffing tagged image bytes', () => {
+    const converted = convertPromptToCodexInput({
+      mode: 'stateless',
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'image',
+              data: { type: 'data', data: Uint8Array.from([0x89, 0x50, 0x4e, 0x47]) },
+            },
+          ],
+        },
+      ] as never,
+    });
+
+    expect(converted.localImages).toHaveLength(1);
+    expect(converted.localImages[0]?.mimeType).toBe('image/png');
+    expect(converted.localImages[0]?.data.startsWith('data:image/png;base64,')).toBe(true);
+    expect(converted.warnings).toEqual([]);
+  });
+
+  it('warns and skips assistant custom parts', () => {
+    const converted = convertPromptToCodexInput({
+      mode: 'stateless',
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'hello' },
+            { type: 'custom', kind: 'acme.widget' },
+          ],
+        },
+      ] as never,
+    });
+
+    expect(converted.text).toBe('Assistant: hello');
+    expect(
+      converted.warnings.some(
+        (warning) =>
+          warning.type === 'unsupported' &&
+          warning.feature === 'prompt.assistant.custom' &&
+          warning.details.includes('acme.widget'),
+      ),
+    ).toBe(true);
+  });
+
+  it('warns and skips assistant reasoning-file parts', () => {
+    const converted = convertPromptToCodexInput({
+      mode: 'stateless',
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'answer' },
+            {
+              type: 'reasoning-file',
+              mediaType: 'application/json',
+              data: { type: 'data', data: 'e30=' },
+            },
+          ],
+        },
+      ] as never,
+    });
+
+    expect(converted.text).toBe('Assistant: answer');
+    expect(
+      converted.warnings.some(
+        (warning) =>
+          warning.type === 'unsupported' &&
+          warning.feature === 'prompt.assistant.reasoning-file',
+      ),
+    ).toBe(true);
   });
 });

--- a/src/__tests__/shared-utils.test.ts
+++ b/src/__tests__/shared-utils.test.ts
@@ -208,6 +208,23 @@ describe('shared-utils', () => {
     expect(features).toContain('toolChoice');
   });
 
+  it("does not warn for toolChoice { type: 'auto' } (ai@7 default normalization)", () => {
+    const warnings = mapUnsupportedSettingsWarnings({ toolChoice: { type: 'auto' } });
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('still warns for meaningful toolChoice values', () => {
+    for (const toolChoice of [
+      { type: 'required' },
+      { type: 'none' },
+      { type: 'tool', toolName: 'x' },
+    ]) {
+      const warnings = mapUnsupportedSettingsWarnings({ toolChoice });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatchObject({ type: 'unsupported', feature: 'toolChoice' });
+    }
+  });
+
   it('converts MCP settings into config override keys', () => {
     const overrides = mcpServersToConfigOverrides(
       {

--- a/src/__tests__/tool-result-converter.test.ts
+++ b/src/__tests__/tool-result-converter.test.ts
@@ -17,28 +17,90 @@ describe('tool-result-converter', () => {
     ).toContain('{"code":400,"detail":"nope"}');
   });
 
-  it('formats content arrays with placeholders for all known content part variants', () => {
+  it('formats canonical file content parts for all tagged data variants', () => {
     const result = formatToolResultOutput({
       type: 'content',
       value: [
         { type: 'text', text: 'line 1' },
-        { type: 'image-url', url: 'https://example.com/a.png' },
-        { type: 'file-data', mediaType: 'application/pdf', data: 'abc' },
-        { type: 'file-url', url: 'https://example.com/a.pdf' },
-        { type: 'file-id', id: 'file_123' },
-        { type: 'image-data', mediaType: 'image/png', data: 'AAAA' },
-        { type: 'image-file-id', id: 'img_123' },
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          data: { type: 'url', url: new URL('https://example.com/a.png') },
+        },
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          filename: 'doc.pdf',
+          data: { type: 'data', data: 'abc=' },
+        },
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          data: { type: 'url', url: new URL('https://example.com/a.pdf') },
+        },
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          data: { type: 'reference', reference: { openai: 'file_123' } },
+        },
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          data: { type: 'data', data: 'AAAA' },
+        },
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          data: { type: 'reference', reference: { openai: 'img_123' } },
+        },
+        {
+          type: 'file',
+          mediaType: 'text/plain',
+          data: { type: 'text', text: 'inline document text' },
+        },
       ],
     } as never);
 
     expect(result.text).toContain('line 1');
     expect(result.text).toContain('[image-url: https://example.com/a.png]');
-    expect(result.text).toContain('[file-data: application/pdf');
+    expect(result.text).toContain('[file-data: application/pdf, doc.pdf]');
     expect(result.text).toContain('[file-url: https://example.com/a.pdf]');
     expect(result.text).toContain('[file-id]');
     expect(result.text).toContain('[image-data: image/png]');
     expect(result.text).toContain('[image-file-id]');
+    expect(result.text).toContain('inline document text');
     expect(result.warnings).toEqual([]);
+  });
+
+  it('classifies top-level segment mediaType as image', () => {
+    const result = formatToolResultOutput({
+      type: 'content',
+      value: [
+        {
+          type: 'file',
+          mediaType: 'image',
+          data: { type: 'url', url: new URL('https://example.com/pic.bin') },
+        },
+      ],
+    } as never);
+
+    expect(result.text).toBe('[image-url: https://example.com/pic.bin]');
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('warns and skips custom content parts', () => {
+    const result = formatToolResultOutput({
+      type: 'content',
+      value: [{ type: 'text', text: 'kept' }, { type: 'custom' }],
+    } as never);
+
+    expect(result.text).toBe('kept');
+    expect(
+      result.warnings.some(
+        (warning) =>
+          warning.type === 'unsupported' && warning.feature === 'tool-result.content.custom',
+      ),
+    ).toBe(true);
   });
 
   it('warns for unsupported content part type inside content output', () => {
@@ -53,6 +115,21 @@ describe('tool-result-converter', () => {
         (warning) =>
           warning.type === 'unsupported' &&
           warning.details.includes('Unsupported tool content part'),
+      ),
+    ).toBe(true);
+  });
+
+  it('warns for unrecognized tagged file data inside content output', () => {
+    const result = formatToolResultOutput({
+      type: 'content',
+      value: [{ type: 'file', mediaType: 'application/pdf', data: { type: 'mystery' } }],
+    } as never);
+
+    expect(result.text).toContain('[unsupported-tool-content-part]');
+    expect(
+      result.warnings.some(
+        (warning) =>
+          warning.type === 'unsupported' && warning.feature === 'tool-result.content.file',
       ),
     ).toBe(true);
   });

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -60,7 +60,7 @@ describe('validateSettings', () => {
     const res = validateAppServerSettings({
       codexPath: '/opt/homebrew/bin/codex',
       personality: 'pragmatic',
-      minCodexVersion: '0.130.0',
+      minCodexVersion: '0.142.5',
       sandboxPolicy: 'workspace-write',
     });
     expect(res.valid).toBe(true);

--- a/src/app-server/language-model.ts
+++ b/src/app-server/language-model.ts
@@ -18,7 +18,11 @@ import type {
 import { NoSuchModelError } from '@ai-sdk/provider';
 import { generateId, parseProviderOptions } from '@ai-sdk/provider-utils';
 import { createVerboseLogger, getLogger } from '../logger.js';
-import { convertPromptToCodexInput, type PromptMessage } from '../converters/index.js';
+import {
+  collectSystemInstruction,
+  convertPromptToCodexInput,
+  type PromptMessage,
+} from '../converters/index.js';
 import { cleanupTempImages, type ImageData, writeImageToTempFile } from '../image-utils.js';
 import {
   createEmptyCodexUsage,
@@ -388,7 +392,8 @@ export class AppServerLanguageModel implements LanguageModelV4 {
     settings: CodexAppServerSettings;
     providerOptions?: CodexAppServerProviderOptions;
     configOverrides?: Record<string, unknown>;
-    developerInstructions?: string;
+    developerInstructionsOverride?: string;
+    systemInstruction?: string;
     includeRawChunks: boolean;
   }): Promise<{
     threadId: string;
@@ -397,8 +402,14 @@ export class AppServerLanguageModel implements LanguageModelV4 {
     resumed: boolean;
     rawEventsNegotiated?: boolean;
   }> {
-    const { settings, providerOptions, configOverrides, developerInstructions, includeRawChunks } =
-      args;
+    const {
+      settings,
+      providerOptions,
+      configOverrides,
+      developerInstructionsOverride,
+      systemInstruction,
+      includeRawChunks,
+    } = args;
     const threadState = this.resolveTargetThreadId(settings, providerOptions);
 
     const startThread = async (ephemeral: boolean) => {
@@ -409,7 +420,7 @@ export class AppServerLanguageModel implements LanguageModelV4 {
         sandbox: mapSandboxToThreadSandboxMode(settings),
         config: configOverrides,
         baseInstructions: settings.baseInstructions,
-        developerInstructions,
+        developerInstructions: developerInstructionsOverride ?? systemInstruction,
         personality: settings.personality,
         ephemeral,
         experimentalRawEvents: includeRawChunks,
@@ -445,7 +456,7 @@ export class AppServerLanguageModel implements LanguageModelV4 {
             sandbox: mapSandboxToThreadSandboxMode(settings),
             config: configOverrides,
             baseInstructions: settings.baseInstructions,
-            developerInstructions,
+            developerInstructions: developerInstructionsOverride,
             personality: settings.personality,
             persistExtendedHistory: settings.persistExtendedHistory ?? false,
           });
@@ -884,15 +895,7 @@ export class AppServerLanguageModel implements LanguageModelV4 {
     const developerInstructionsOverride =
       providerOptions?.developerInstructions ?? settings.developerInstructions;
 
-    const threadState = this.resolveTargetThreadId(settings, providerOptions);
-    const prompt = this.preparePrompt(options.prompt as unknown[], Boolean(threadState.threadId));
-
-    warnings.push(...prompt.warnings);
-
-    const effectiveDeveloperInstructions =
-      developerInstructionsOverride ??
-      (!threadState.threadId ? prompt.systemInstruction : undefined);
-
+    const systemInstruction = collectSystemInstruction(options.prompt as readonly PromptMessage[]);
     const resolvedConfig = await this.resolveConfig(settings, sdkServerLifecycle);
     let releasedSdkServers = false;
     const releaseUsedSdkMcpServers = () => {
@@ -911,7 +914,8 @@ export class AppServerLanguageModel implements LanguageModelV4 {
         settings,
         providerOptions,
         configOverrides: resolvedConfig.configOverrides,
-        developerInstructions: effectiveDeveloperInstructions,
+        developerInstructionsOverride,
+        systemInstruction,
         includeRawChunks,
       });
     } catch (error) {
@@ -932,6 +936,10 @@ export class AppServerLanguageModel implements LanguageModelV4 {
           'includeRawChunks was requested while resuming an existing thread that may not emit raw events. Start a new thread to guarantee raw chunk events.',
       });
     }
+
+    const prompt = this.preparePrompt(options.prompt as unknown[], threadResolution.resumed);
+
+    warnings.push(...prompt.warnings);
 
     let input: UserInput[] = [];
     let tempImagePaths: string[] = [];
@@ -975,7 +983,7 @@ export class AppServerLanguageModel implements LanguageModelV4 {
       session,
       abortSignal: options.abortSignal,
       shouldSerializeTurnStart: threadResolution.persistent || threadResolution.explicit,
-      hadInitialThreadId: Boolean(threadState.threadId),
+      hadInitialThreadId: threadResolution.resumed,
       threadResolution: {
         persistent: threadResolution.persistent,
         explicit: threadResolution.explicit,

--- a/src/app-server/language-model.ts
+++ b/src/app-server/language-model.ts
@@ -75,7 +75,7 @@ function resolveReasoningEffort(args: {
     return { effort: args.defaultEffort };
   }
 
-  if (CODEX_REASONING_EFFORTS[reasoning]) {
+  if (Object.hasOwn(CODEX_REASONING_EFFORTS, reasoning)) {
     return { effort: reasoning as ReasoningEffort };
   }
 

--- a/src/app-server/language-model.ts
+++ b/src/app-server/language-model.ts
@@ -211,6 +211,7 @@ export class AppServerLanguageModel implements LanguageModelV4 {
 
   private persistentThreadId?: string;
   private persistentThreadRawEventsEnabled?: boolean;
+  private readonly rawEventsByThreadId = new Map<string, boolean>();
   private persistentSession?: AppServerSession;
   private persistentBootstrapLock = Promise.resolve();
 
@@ -456,15 +457,20 @@ export class AppServerLanguageModel implements LanguageModelV4 {
             sandbox: mapSandboxToThreadSandboxMode(settings),
             config: configOverrides,
             baseInstructions: settings.baseInstructions,
-            developerInstructions: developerInstructionsOverride,
+            developerInstructions: developerInstructionsOverride ?? systemInstruction,
             personality: settings.personality,
             persistExtendedHistory: settings.persistExtendedHistory ?? false,
           });
 
+          const cachedRawEvents = this.rawEventsByThreadId.get(target.threadId);
           const knownRawEvents =
-            target.persistent && this.persistentThreadId === target.threadId
+            cachedRawEvents ??
+            (target.persistent && this.persistentThreadId === target.threadId
               ? this.persistentThreadRawEventsEnabled
-              : undefined;
+              : undefined);
+          if (cachedRawEvents !== undefined) {
+            this.rememberThreadRawEvents(target.threadId, cachedRawEvents);
+          }
           if (target.persistent) {
             this.persistentThreadId = target.threadId;
             this.persistentThreadRawEventsEnabled = knownRawEvents;
@@ -498,6 +504,7 @@ export class AppServerLanguageModel implements LanguageModelV4 {
         }
 
         const newThreadId = await startThread(false);
+        this.rememberThreadRawEvents(newThreadId, includeRawChunks);
         this.persistentThreadId = newThreadId;
         this.persistentThreadRawEventsEnabled = includeRawChunks;
         return {
@@ -511,6 +518,7 @@ export class AppServerLanguageModel implements LanguageModelV4 {
 
       if (!threadState.threadId) {
         const newThreadId = await startThread(!threadState.persistent);
+        this.rememberThreadRawEvents(newThreadId, includeRawChunks);
         if (threadState.persistent) {
           this.persistentThreadId = newThreadId;
           this.persistentThreadRawEventsEnabled = includeRawChunks;
@@ -560,6 +568,20 @@ export class AppServerLanguageModel implements LanguageModelV4 {
     }
   }
 
+  private rememberThreadRawEvents(threadId: string, enabled: boolean): void {
+    this.rawEventsByThreadId.delete(threadId);
+    this.rawEventsByThreadId.set(threadId, enabled);
+
+    if (this.rawEventsByThreadId.size <= 256) {
+      return;
+    }
+
+    const oldestThreadId = this.rawEventsByThreadId.keys().next().value;
+    if (typeof oldestThreadId === 'string') {
+      this.rawEventsByThreadId.delete(oldestThreadId);
+    }
+  }
+
   private clearPersistentThreadState(threadId?: string): void {
     if (threadId && this.persistentThreadId && this.persistentThreadId !== threadId) {
       return;
@@ -567,6 +589,9 @@ export class AppServerLanguageModel implements LanguageModelV4 {
 
     this.persistentThreadId = undefined;
     this.persistentThreadRawEventsEnabled = undefined;
+    if (threadId) {
+      this.rawEventsByThreadId.delete(threadId);
+    }
 
     if (!threadId || this.persistentSession?.threadId === threadId) {
       this.persistentSession = undefined;

--- a/src/app-server/language-model.ts
+++ b/src/app-server/language-model.ts
@@ -456,9 +456,7 @@ export class AppServerLanguageModel implements LanguageModelV4 {
               : undefined;
           if (target.persistent) {
             this.persistentThreadId = target.threadId;
-            if (target.explicit) {
-              this.persistentThreadRawEventsEnabled = undefined;
-            }
+            this.persistentThreadRawEventsEnabled = knownRawEvents;
           }
 
           return {

--- a/src/app-server/language-model.ts
+++ b/src/app-server/language-model.ts
@@ -79,12 +79,14 @@ function resolveReasoningEffort(args: {
     return { effort: reasoning as ReasoningEffort };
   }
 
+  // Align with the exec provider: ignore the unmappable value and fall back
+  // to the otherwise-configured effort (providerOptions > settings default).
   return {
-    effort: undefined,
+    effort: args.defaultEffort,
     warning: {
       type: 'unsupported',
       feature: 'reasoning',
-      details: `Codex app-server does not support reasoning effort '${reasoning}'; effort will be unset.`,
+      details: `Codex app-server does not support reasoning effort '${reasoning}'; it will be ignored.`,
     },
   };
 }

--- a/src/app-server/language-model.ts
+++ b/src/app-server/language-model.ts
@@ -1,19 +1,19 @@
 import type {
-  LanguageModelV3,
-  LanguageModelV3Content,
-  LanguageModelV3File,
-  LanguageModelV3FinishReason,
-  LanguageModelV3Reasoning,
-  LanguageModelV3Source,
-  LanguageModelV3StreamPart,
-  LanguageModelV3Text,
-  LanguageModelV3ToolApprovalRequest,
-  LanguageModelV3ToolCall,
-  LanguageModelV3ToolResult,
-  LanguageModelV3Usage,
-  LanguageModelV3ResponseMetadata,
-  SharedV3ProviderMetadata,
-  SharedV3Warning,
+  LanguageModelV4,
+  LanguageModelV4Content,
+  LanguageModelV4File,
+  LanguageModelV4FinishReason,
+  LanguageModelV4Reasoning,
+  LanguageModelV4Source,
+  LanguageModelV4StreamPart,
+  LanguageModelV4Text,
+  LanguageModelV4ToolApprovalRequest,
+  LanguageModelV4ToolCall,
+  LanguageModelV4ToolResult,
+  LanguageModelV4Usage,
+  LanguageModelV4ResponseMetadata,
+  SharedV4ProviderMetadata,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import { NoSuchModelError } from '@ai-sdk/provider';
 import { generateId, parseProviderOptions } from '@ai-sdk/provider-utils';
@@ -34,7 +34,7 @@ import type {
   CodexAppServerRequestHandlers,
   CodexAppServerSettings,
 } from './types.js';
-import type { CodexModelId, Logger, McpServerConfig } from '../types-shared.js';
+import type { CodexModelId, Logger, McpServerConfig, ReasoningEffort } from '../types-shared.js';
 import type { UserInput } from './protocol/types.js';
 import { AppServerRpcClient } from './rpc/client.js';
 import { AppServerSession } from './session.js';
@@ -51,6 +51,43 @@ type PromptImage =
       type: 'remote';
       url: string;
     };
+
+const CODEX_REASONING_EFFORTS: Record<string, true> = {
+  none: true,
+  minimal: true,
+  low: true,
+  medium: true,
+  high: true,
+  xhigh: true,
+};
+
+function resolveReasoningEffort(args: {
+  reasoning: string | undefined;
+  providerEffort: ReasoningEffort | undefined;
+  defaultEffort: ReasoningEffort | undefined;
+}): { effort: ReasoningEffort | undefined; warning?: SharedV4Warning } {
+  if (args.providerEffort !== undefined) {
+    return { effort: args.providerEffort };
+  }
+
+  const { reasoning } = args;
+  if (reasoning === undefined || reasoning === 'provider-default') {
+    return { effort: args.defaultEffort };
+  }
+
+  if (CODEX_REASONING_EFFORTS[reasoning]) {
+    return { effort: reasoning as ReasoningEffort };
+  }
+
+  return {
+    effort: undefined,
+    warning: {
+      type: 'unsupported',
+      feature: 'reasoning',
+      details: `Codex app-server does not support reasoning effort '${reasoning}'; effort will be unset.`,
+    },
+  };
+}
 
 function isThreadNotFoundError(error: unknown): boolean {
   const message = String((error as Error)?.message ?? error);
@@ -150,13 +187,10 @@ export interface AppServerLanguageModelOptions {
   onSdkMcpServerReleased?: (server: SdkMcpServer) => void;
 }
 
-export class AppServerLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = 'v3' as const;
+export class AppServerLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4' as const;
   readonly provider = 'codex-app-server';
-  readonly defaultObjectGenerationMode = 'json' as const;
-  readonly supportsImageUrls = true;
   readonly supportedUrls = {};
-  readonly supportsStructuredOutputs = true;
 
   readonly modelId: string;
   readonly settings: CodexAppServerSettings;
@@ -574,7 +608,7 @@ export class AppServerLanguageModel implements LanguageModelV3 {
   ): {
     promptText: string;
     images: PromptImage[];
-    warnings: SharedV3Warning[];
+    warnings: SharedV4Warning[];
     systemInstruction?: string;
   } {
     const converted = convertPromptToCodexInput({
@@ -605,38 +639,38 @@ export class AppServerLanguageModel implements LanguageModelV3 {
   }
 
   async doGenerate(
-    options: Parameters<LanguageModelV3['doGenerate']>[0],
-  ): Promise<Awaited<ReturnType<LanguageModelV3['doGenerate']>>> {
+    options: Parameters<LanguageModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<LanguageModelV4['doGenerate']>>> {
     const { stream, request } = await this.doStream(
-      options as Parameters<LanguageModelV3['doStream']>[0],
+      options as Parameters<LanguageModelV4['doStream']>[0],
     );
 
-    const content: LanguageModelV3Content[] = [];
-    const textPartsById = new Map<string, LanguageModelV3Text>();
-    const reasoningPartsById = new Map<string, LanguageModelV3Reasoning>();
+    const content: LanguageModelV4Content[] = [];
+    const textPartsById = new Map<string, LanguageModelV4Text>();
+    const reasoningPartsById = new Map<string, LanguageModelV4Reasoning>();
     let activeTextBlockId: string | undefined;
     let activeReasoningBlockId: string | undefined;
-    let responseMetadata: LanguageModelV3ResponseMetadata = {
+    let responseMetadata: LanguageModelV4ResponseMetadata = {
       id: generateId(),
       timestamp: new Date(),
       modelId: this.modelId,
     };
-    let usage: LanguageModelV3Usage = createEmptyCodexUsage();
-    let finishReason: LanguageModelV3FinishReason = { unified: 'other', raw: undefined };
-    let warnings: SharedV3Warning[] = [];
-    let providerMetadata: SharedV3ProviderMetadata | undefined;
+    let usage: LanguageModelV4Usage = createEmptyCodexUsage();
+    let finishReason: LanguageModelV4FinishReason = { unified: 'other', raw: undefined };
+    let warnings: SharedV4Warning[] = [];
+    let providerMetadata: SharedV4ProviderMetadata | undefined;
 
     const ensureTextPart = (
       id: string,
-      metadata?: SharedV3ProviderMetadata,
-    ): LanguageModelV3Text => {
+      metadata?: SharedV4ProviderMetadata,
+    ): LanguageModelV4Text => {
       const existing = textPartsById.get(id);
       if (existing) {
         if (metadata) existing.providerMetadata = metadata;
         return existing;
       }
 
-      const part: LanguageModelV3Text = {
+      const part: LanguageModelV4Text = {
         type: 'text',
         text: '',
         ...(metadata ? { providerMetadata: metadata } : {}),
@@ -648,15 +682,15 @@ export class AppServerLanguageModel implements LanguageModelV3 {
 
     const ensureReasoningPart = (
       id: string,
-      metadata?: SharedV3ProviderMetadata,
-    ): LanguageModelV3Reasoning => {
+      metadata?: SharedV4ProviderMetadata,
+    ): LanguageModelV4Reasoning => {
       const existing = reasoningPartsById.get(id);
       if (existing) {
         if (metadata) existing.providerMetadata = metadata;
         return existing;
       }
 
-      const part: LanguageModelV3Reasoning = {
+      const part: LanguageModelV4Reasoning = {
         type: 'reasoning',
         text: '',
         ...(metadata ? { providerMetadata: metadata } : {}),
@@ -668,16 +702,16 @@ export class AppServerLanguageModel implements LanguageModelV3 {
 
     const pushContentPart = (
       part:
-        | LanguageModelV3File
-        | LanguageModelV3Source
-        | LanguageModelV3ToolApprovalRequest
-        | LanguageModelV3ToolCall
-        | LanguageModelV3ToolResult,
+        | LanguageModelV4File
+        | LanguageModelV4Source
+        | LanguageModelV4ToolApprovalRequest
+        | LanguageModelV4ToolCall
+        | LanguageModelV4ToolResult,
     ): void => {
       content.push(part);
     };
 
-    for await (const part of stream as AsyncIterable<LanguageModelV3StreamPart>) {
+    for await (const part of stream as AsyncIterable<LanguageModelV4StreamPart>) {
       if (part.type === 'stream-start') {
         warnings = part.warnings;
         continue;
@@ -802,15 +836,24 @@ export class AppServerLanguageModel implements LanguageModelV3 {
   }
 
   async doStream(
-    options: Parameters<LanguageModelV3['doStream']>[0],
-  ): Promise<Awaited<ReturnType<LanguageModelV3['doStream']>>> {
+    options: Parameters<LanguageModelV4['doStream']>[0],
+  ): Promise<Awaited<ReturnType<LanguageModelV4['doStream']>>> {
     const providerOptions = await parseProviderOptions<CodexAppServerProviderOptions>({
       provider: this.provider,
       providerOptions: options.providerOptions,
       schema: appServerProviderOptionsSchema as never,
     });
 
-    const settings = this.mergeSettings(providerOptions);
+    const mergedSettings = this.mergeSettings(providerOptions);
+    const resolvedReasoning = resolveReasoningEffort({
+      reasoning: options.reasoning,
+      providerEffort: providerOptions?.effort,
+      defaultEffort: mergedSettings.effort,
+    });
+    const settings: CodexAppServerSettings =
+      resolvedReasoning.effort === mergedSettings.effort
+        ? mergedSettings
+        : { ...mergedSettings, effort: resolvedReasoning.effort };
     const sdkServerLifecycle: 'provider' | 'request' =
       this.resolveThreadMode(settings, providerOptions) === 'persistent' ? 'provider' : 'request';
     const includeRawChunks = this.resolveIncludeRawChunks(
@@ -819,7 +862,7 @@ export class AppServerLanguageModel implements LanguageModelV3 {
       providerOptions,
     );
 
-    const warnings: SharedV3Warning[] = [
+    const warnings: SharedV4Warning[] = [
       ...mapUnsupportedSettingsWarnings({
         temperature: options.temperature,
         topP: options.topP,
@@ -833,6 +876,10 @@ export class AppServerLanguageModel implements LanguageModelV3 {
         toolChoice: (options as { toolChoice?: unknown }).toolChoice,
       }),
     ];
+
+    if (resolvedReasoning.warning) {
+      warnings.push(resolvedReasoning.warning);
+    }
 
     const developerInstructionsOverride =
       providerOptions?.developerInstructions ?? settings.developerInstructions;
@@ -942,7 +989,7 @@ export class AppServerLanguageModel implements LanguageModelV3 {
       },
     });
 
-    const stream = new ReadableStream<LanguageModelV3StreamPart>({
+    const stream = new ReadableStream<LanguageModelV4StreamPart>({
       start: async (controller) => {
         await turnStreamController.start(controller);
       },

--- a/src/app-server/protocol/types.ts
+++ b/src/app-server/protocol/types.ts
@@ -35,12 +35,16 @@ export type JsonRpcMessage =
 
 export interface ClientInfo {
   name: string;
-  title?: string;
+  title?: string | null;
   version: string;
 }
 
 export interface InitializeCapabilities {
   experimentalApi: boolean;
+  /** Opt into `attestation/generate` requests (codex >= 0.142). */
+  requestAttestation?: boolean;
+  /** Allow MCP servers to request OpenAI extended form elicitations (codex >= 0.142). */
+  mcpServerOpenaiFormElicitation?: boolean;
   optOutNotificationMethods?: string[] | null;
 }
 
@@ -51,21 +55,46 @@ export interface InitializeParams {
 
 export interface InitializeResponse {
   userAgent: string;
+  /** Absolute path to the server's $CODEX_HOME directory (codex >= 0.142). */
+  codexHome?: string;
+  /** Platform family, e.g. 'unix' or 'windows' (codex >= 0.142). */
+  platformFamily?: string;
+  /** Operating system, e.g. 'macos', 'linux', 'windows' (codex >= 0.142). */
+  platformOs?: string;
+  /** External contract: only pre-0.142 servers return this; codex 0.142.5 omits it. */
   capabilities?: Record<string, unknown> | null;
 }
 
 export interface ModelListParams {
+  /**
+   * External contract: accepted by pre-0.142 servers only. Codex 0.142.5
+   * removed this param and ignores it when sent (verified empirically).
+   */
   modelProviders?: string[] | null;
   cursor?: string | null;
   limit?: number | null;
+  /** Include models hidden from the default picker list (codex >= 0.142). */
+  includeHidden?: boolean | null;
 }
 
+/**
+ * Vendored subset of the codex 0.142.5 `Model` wire type (renamed upstream
+ * from `ModelInfo`), plus fields only pre-0.142 servers return.
+ */
 export interface ModelInfo {
   id: string;
-  name?: string | null;
-  modelProvider?: string | null;
+  /** Underlying model slug (codex >= 0.142). */
+  model?: string;
+  /** Display name; replaces the pre-0.142 `name` field (codex >= 0.142). */
+  displayName?: string;
   description?: string | null;
+  /** Whether the model is hidden from the default picker list (codex >= 0.142). */
+  hidden?: boolean;
   isDefault?: boolean | null;
+  /** External contract: only pre-0.142 servers return `name`. */
+  name?: string | null;
+  /** External contract: only pre-0.142 servers return `modelProvider`. */
+  modelProvider?: string | null;
   [k: string]: unknown;
 }
 
@@ -93,8 +122,12 @@ export interface ThreadStartParams {
   developerInstructions?: string | null;
   personality?: 'none' | 'friendly' | 'pragmatic' | null;
   ephemeral?: boolean | null;
-  experimentalRawEvents: boolean;
-  persistExtendedHistory: boolean;
+  experimentalRawEvents?: boolean;
+  /**
+   * External contract: consumed by pre-0.142 servers only. Codex 0.142.5
+   * removed this param and ignores it when sent (verified empirically).
+   */
+  persistExtendedHistory?: boolean;
 }
 
 export interface ThreadStartResponse {
@@ -120,15 +153,31 @@ export interface ThreadResumeParams {
   baseInstructions?: string | null;
   developerInstructions?: string | null;
   personality?: 'none' | 'friendly' | 'pragmatic' | null;
-  persistExtendedHistory: boolean;
+  /**
+   * External contract: consumed by pre-0.142 servers only. Codex 0.142.5
+   * removed this param and ignores it when sent.
+   */
+  persistExtendedHistory?: boolean;
 }
 
 export type ThreadResumeResponse = ThreadStartResponse;
 
 export type UserInput =
   | { type: 'text'; text: string; text_elements: unknown[] }
-  | { type: 'image'; url?: string; imageUrl?: string }
-  | { type: 'localImage'; path: string }
+  | {
+      type: 'image';
+      url: string;
+      /** Optional rendering detail hint (codex >= 0.142). */
+      detail?: 'auto' | 'low' | 'high' | 'original';
+      /** External contract: pre-0.142 servers read `imageUrl`; codex 0.142.5 only reads `url`. */
+      imageUrl?: string;
+    }
+  | {
+      type: 'localImage';
+      path: string;
+      /** Optional rendering detail hint (codex >= 0.142). */
+      detail?: 'auto' | 'low' | 'high' | 'original';
+    }
   | { type: 'skill'; name: string; path: string }
   | { type: 'mention'; name: string; path: string };
 
@@ -139,7 +188,12 @@ export interface TurnStartParams {
   approvalPolicy?: unknown;
   sandboxPolicy?: unknown;
   model?: string | null;
-  effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | null;
+  /**
+   * Reasoning effort. Open-ended string upstream (`ReasoningEffort = string`
+   * in codex 0.142.5); known values include 'none', 'minimal', 'low',
+   * 'medium', 'high', 'xhigh', and 'ultra'.
+   */
+  effort?: string | null;
   summary?: 'auto' | 'concise' | 'detailed' | 'none' | null;
   personality?: 'none' | 'friendly' | 'pragmatic' | null;
   outputSchema?: unknown;
@@ -150,6 +204,7 @@ export type CodexErrorInfo =
   | 'contextWindowExceeded'
   | 'usageLimitExceeded'
   | 'serverOverloaded'
+  | 'cyberPolicy'
   | 'internalServerError'
   | 'unauthorized'
   | 'badRequest'
@@ -159,7 +214,8 @@ export type CodexErrorInfo =
   | { httpConnectionFailed: { httpStatusCode: number | null } }
   | { responseStreamConnectionFailed: { httpStatusCode: number | null } }
   | { responseStreamDisconnected: { httpStatusCode: number | null } }
-  | { responseTooManyFailedAttempts: { httpStatusCode: number | null } };
+  | { responseTooManyFailedAttempts: { httpStatusCode: number | null } }
+  | { activeTurnNotSteerable: { turnKind: 'review' | 'compact' } };
 
 export interface TurnError {
   message: string;
@@ -172,6 +228,8 @@ export type TurnStatus = 'completed' | 'interrupted' | 'failed' | 'inProgress';
 export type UserMessageItem = {
   type: 'userMessage';
   id: string;
+  /** Client-supplied message id echoed back by the server (codex >= 0.142). */
+  clientId?: string | null;
   content: UserInput[];
 };
 
@@ -180,6 +238,8 @@ export type AgentMessageItem = {
   id: string;
   text: string;
   phase: string | null;
+  /** Memory citation metadata (codex >= 0.142). */
+  memoryCitation?: unknown | null;
 };
 
 export type PlanItem = {
@@ -201,6 +261,8 @@ export type CommandExecutionItem = {
   command: string;
   cwd: string;
   processId: string | null;
+  /** 'agent' | 'userShell' | 'unifiedExecStartup' | 'unifiedExecInteraction' (codex >= 0.142). */
+  source?: string;
   status: string;
   commandActions: unknown[];
   aggregatedOutput: string | null;
@@ -222,6 +284,10 @@ export type McpToolCallItem = {
   tool: string;
   status: string;
   arguments: unknown;
+  /** MCP app context; replaces `mcpAppResourceUri` (codex >= 0.142). */
+  appContext?: unknown | null;
+  mcpAppResourceUri?: string;
+  pluginId?: string | null;
   result: unknown | null;
   error: unknown | null;
   durationMs: number | null;
@@ -235,6 +301,10 @@ export type CollabAgentToolCallItem = {
   senderThreadId: string;
   receiverThreadIds: string[];
   prompt: string | null;
+  /** Model requested for the spawned agent, when applicable (codex >= 0.142). */
+  model?: string | null;
+  /** Reasoning effort requested for the spawned agent, when applicable (codex >= 0.142). */
+  reasoningEffort?: string | null;
   agentsStates: Record<string, unknown>;
 };
 
@@ -268,6 +338,52 @@ export type ContextCompactionItem = {
   id: string;
 };
 
+/** codex >= 0.142. */
+export type HookPromptItem = {
+  type: 'hookPrompt';
+  id: string;
+  fragments: unknown[];
+};
+
+/** SDK-registered dynamic tool call surfaced as a thread item (codex >= 0.142). */
+export type DynamicToolCallItem = {
+  type: 'dynamicToolCall';
+  id: string;
+  namespace: string | null;
+  tool: string;
+  arguments: unknown;
+  status: string;
+  contentItems: unknown[] | null;
+  success: boolean | null;
+  durationMs: number | null;
+};
+
+/** codex >= 0.142. */
+export type SubAgentActivityItem = {
+  type: 'subAgentActivity';
+  id: string;
+  kind: string;
+  agentThreadId: string;
+  agentPath: string;
+};
+
+/** codex >= 0.142. */
+export type SleepItem = {
+  type: 'sleep';
+  id: string;
+  durationMs: number;
+};
+
+/** codex >= 0.142. */
+export type ImageGenerationItem = {
+  type: 'imageGeneration';
+  id: string;
+  status: string;
+  revisedPrompt: string | null;
+  result: string;
+  savedPath?: string;
+};
+
 export type ThreadItem =
   | UserMessageItem
   | AgentMessageItem
@@ -276,7 +392,12 @@ export type ThreadItem =
   | CommandExecutionItem
   | FileChangeItem
   | McpToolCallItem
+  | DynamicToolCallItem
   | CollabAgentToolCallItem
+  | HookPromptItem
+  | SubAgentActivityItem
+  | SleepItem
+  | ImageGenerationItem
   | WebSearchItem
   | ImageViewItem
   | EnteredReviewModeItem
@@ -286,8 +407,13 @@ export type ThreadItem =
 export interface Turn {
   id: string;
   items: ThreadItem[];
+  /** 'notLoaded' | 'summary' | 'full' (codex >= 0.142). */
+  itemsView?: string;
   status: TurnStatus;
   error: TurnError | null;
+  startedAt?: number | null;
+  completedAt?: number | null;
+  durationMs?: number | null;
 }
 
 export interface TurnStartResponse {
@@ -319,12 +445,16 @@ export interface ItemStartedNotification {
   item: ThreadItem;
   threadId: string;
   turnId: string;
+  /** Unix timestamp (ms) when this item lifecycle started (codex >= 0.142). */
+  startedAtMs?: number;
 }
 
 export interface ItemCompletedNotification {
   item: ThreadItem;
   threadId: string;
   turnId: string;
+  /** Unix timestamp (ms) when this item lifecycle completed (codex >= 0.142). */
+  completedAtMs?: number;
 }
 
 export interface AgentMessageDeltaNotification {
@@ -339,6 +469,8 @@ export interface ReasoningTextDeltaNotification {
   turnId: string;
   itemId: string;
   delta: string;
+  /** Index into the reasoning item's `content` array (codex >= 0.142). */
+  contentIndex?: number;
 }
 
 export interface ReasoningSummaryTextDeltaNotification {
@@ -346,6 +478,8 @@ export interface ReasoningSummaryTextDeltaNotification {
   turnId: string;
   itemId: string;
   delta: string;
+  /** Index into the reasoning item's `summary` array (codex >= 0.142). */
+  summaryIndex?: number;
 }
 
 export interface CommandExecutionOutputDeltaNotification {
@@ -355,6 +489,10 @@ export interface CommandExecutionOutputDeltaNotification {
   delta: string;
 }
 
+/**
+ * External contract: codex 0.142.5 marks this notification deprecated and no
+ * longer emits it; only pre-0.142 servers do.
+ */
 export interface FileChangeOutputDeltaNotification {
   threadId: string;
   turnId: string;
@@ -394,13 +532,23 @@ export interface CommandExecutionRequestApprovalParams {
   threadId: string;
   turnId: string;
   itemId: string;
+  /** Unix timestamp (ms) when this approval request started (codex >= 0.142). */
+  startedAtMs?: number;
   approvalId?: string | null;
+  /** Environment in which the command will run (codex >= 0.142). */
+  environmentId?: string | null;
   reason?: string | null;
   networkApprovalContext?: unknown | null;
   command?: string | null;
   cwd?: string | null;
   commandActions?: unknown[] | null;
+  /** Additional permissions requested for this command (codex >= 0.142). */
+  additionalPermissions?: unknown | null;
   proposedExecpolicyAmendment?: unknown | null;
+  /** Proposed network policy amendments for future requests (codex >= 0.142). */
+  proposedNetworkPolicyAmendments?: unknown[] | null;
+  /** Ordered decisions the client may present for this prompt (codex >= 0.142). */
+  availableDecisions?: unknown[] | null;
 }
 
 export interface CommandExecutionRequestApprovalResponse {
@@ -409,13 +557,16 @@ export interface CommandExecutionRequestApprovalResponse {
     | 'acceptForSession'
     | 'decline'
     | 'cancel'
-    | { acceptWithExecpolicyAmendment: { execpolicy_amendment: unknown } };
+    | { acceptWithExecpolicyAmendment: { execpolicy_amendment: unknown } }
+    | { applyNetworkPolicyAmendment: { network_policy_amendment: unknown } };
 }
 
 export interface FileChangeRequestApprovalParams {
   threadId: string;
   turnId: string;
   itemId: string;
+  /** Unix timestamp (ms) when this approval request started (codex >= 0.142). */
+  startedAtMs?: number;
   reason?: string | null;
   grantRoot?: string | null;
 }
@@ -424,11 +575,19 @@ export interface FileChangeRequestApprovalResponse {
   decision: 'accept' | 'acceptForSession' | 'decline' | 'cancel';
 }
 
+/**
+ * External contract: `skill/requestApproval` was removed from the codex
+ * 0.142.5 server-request surface; only pre-0.142 servers send it.
+ */
 export interface SkillRequestApprovalParams {
   itemId: string;
   skillName: string;
 }
 
+/**
+ * External contract: `skill/requestApproval` was removed from the codex
+ * 0.142.5 server-request surface; only pre-0.142 servers send it.
+ */
 export interface SkillRequestApprovalResponse {
   decision: 'approve' | 'decline';
 }
@@ -438,6 +597,8 @@ export interface ToolRequestUserInputParams {
   turnId: string;
   itemId: string;
   questions: unknown[];
+  /** Auto-resolution deadline in milliseconds, when set (codex >= 0.142). */
+  autoResolutionMs?: number | null;
 }
 
 export interface ToolRequestUserInputResponse {
@@ -451,7 +612,10 @@ export interface McpServerElicitationRequestParams {
   /** Nullable: the elicitation may arrive outside of an active turn. */
   turnId?: string | null;
   serverName: string;
-  /** 'form' requests carry message/requestedSchema; 'url' requests carry url/elicitationId. */
+  /**
+   * 'form' and 'openai/form' (codex >= 0.142) requests carry
+   * message/requestedSchema; 'url' requests carry url/elicitationId.
+   */
   mode?: string;
   message?: string;
   requestedSchema?: unknown;
@@ -468,12 +632,16 @@ export interface McpServerElicitationRequestResponse {
   action: McpServerElicitationAction;
   /** Structured user input for accepted elicitations; null for decline/cancel. */
   content?: Record<string, unknown> | null;
+  /** Optional client metadata for form-mode action handling (codex >= 0.142). */
+  _meta?: Record<string, unknown> | null;
 }
 
 export interface DynamicToolCallParams {
   threadId: string;
   turnId: string;
   callId: string;
+  /** Dynamic tool namespace (codex >= 0.142). */
+  namespace?: string | null;
   tool: string;
   arguments: unknown;
 }
@@ -484,6 +652,7 @@ export interface DynamicToolCallResponse {
 }
 
 export interface ChatgptAuthTokensRefreshParams {
+  /** Codex 0.142.5 only sends 'unauthorized'; kept open for forward compat. */
   reason: string;
   previousAccountId?: string | null;
 }

--- a/src/app-server/protocol/validators.ts
+++ b/src/app-server/protocol/validators.ts
@@ -273,7 +273,19 @@ const imageGenerationItemSchema = z
   })
   .passthrough();
 
-export const threadItemSchema = z.discriminatedUnion('type', [
+// Forward-compat: codex regularly ships new thread item types (0.142 alone
+// added five). Unknown variants must still validate — the RPC client drops
+// notifications that fail schema validation, and dropping `turn/completed`
+// would hang the stream forever. Routing requires only a string `type`
+// (every other item field is typeof-guarded at the consumer); unknown items
+// flow through as raw chunks and are ignored by tool mapping.
+const unknownThreadItemSchema = z
+  .object({
+    type: z.string(),
+  })
+  .passthrough();
+
+const knownThreadItemSchema = z.discriminatedUnion('type', [
   userMessageItemSchema,
   agentMessageItemSchema,
   planItemSchema,
@@ -293,6 +305,8 @@ export const threadItemSchema = z.discriminatedUnion('type', [
   exitedReviewModeItemSchema,
   contextCompactionItemSchema,
 ]);
+
+export const threadItemSchema = knownThreadItemSchema.or(unknownThreadItemSchema);
 
 const codexHttpStatusCodeSchema = z
   .object({
@@ -320,6 +334,11 @@ const codexErrorInfoSchema = z.union([
   z
     .object({ activeTurnNotSteerable: z.object({ turnKind: z.string() }).passthrough() })
     .passthrough(),
+  // Forward-compat catch-alls: consumers only compare against the known string
+  // codes above (unknown codes fall back to the generic error path), so a new
+  // errorInfo variant must never fail validation and drop the notification.
+  z.string(),
+  z.record(z.string(), z.unknown()),
 ]);
 
 export const turnSchema = z

--- a/src/app-server/protocol/validators.ts
+++ b/src/app-server/protocol/validators.ts
@@ -48,6 +48,8 @@ const userInputTextSchema = z
   })
   .passthrough();
 
+// Codex 0.142.5 always emits `url`; the refine keeps tolerance for pre-0.142
+// servers that emitted `imageUrl` instead.
 const userInputImageSchema = z
   .object({
     type: z.literal('image'),
@@ -215,6 +217,62 @@ const contextCompactionItemSchema = z
   })
   .passthrough();
 
+// codex >= 0.142
+const hookPromptItemSchema = z
+  .object({
+    type: z.literal('hookPrompt'),
+    id: z.string(),
+    fragments: z.array(z.unknown()),
+  })
+  .passthrough();
+
+// codex >= 0.142
+const dynamicToolCallItemSchema = z
+  .object({
+    type: z.literal('dynamicToolCall'),
+    id: z.string(),
+    namespace: z.string().nullable(),
+    tool: z.string(),
+    arguments: z.unknown(),
+    status: z.string(),
+    contentItems: z.array(z.unknown()).nullable(),
+    success: z.boolean().nullable(),
+    durationMs: z.number().nullable(),
+  })
+  .passthrough();
+
+// codex >= 0.142
+const subAgentActivityItemSchema = z
+  .object({
+    type: z.literal('subAgentActivity'),
+    id: z.string(),
+    kind: z.string(),
+    agentThreadId: z.string(),
+    agentPath: z.string(),
+  })
+  .passthrough();
+
+// codex >= 0.142
+const sleepItemSchema = z
+  .object({
+    type: z.literal('sleep'),
+    id: z.string(),
+    durationMs: z.number(),
+  })
+  .passthrough();
+
+// codex >= 0.142
+const imageGenerationItemSchema = z
+  .object({
+    type: z.literal('imageGeneration'),
+    id: z.string(),
+    status: z.string(),
+    revisedPrompt: z.string().nullable(),
+    result: z.string(),
+    savedPath: z.string().optional(),
+  })
+  .passthrough();
+
 export const threadItemSchema = z.discriminatedUnion('type', [
   userMessageItemSchema,
   agentMessageItemSchema,
@@ -223,7 +281,12 @@ export const threadItemSchema = z.discriminatedUnion('type', [
   commandExecutionItemSchema,
   fileChangeItemSchema,
   mcpToolCallItemSchema,
+  dynamicToolCallItemSchema,
   collabAgentToolCallItemSchema,
+  hookPromptItemSchema,
+  subAgentActivityItemSchema,
+  sleepItemSchema,
+  imageGenerationItemSchema,
   webSearchItemSchema,
   imageViewItemSchema,
   enteredReviewModeItemSchema,
@@ -242,6 +305,7 @@ const codexErrorInfoSchema = z.union([
     'contextWindowExceeded',
     'usageLimitExceeded',
     'serverOverloaded',
+    'cyberPolicy',
     'internalServerError',
     'unauthorized',
     'badRequest',
@@ -253,6 +317,9 @@ const codexErrorInfoSchema = z.union([
   z.object({ responseStreamConnectionFailed: codexHttpStatusCodeSchema }).passthrough(),
   z.object({ responseStreamDisconnected: codexHttpStatusCodeSchema }).passthrough(),
   z.object({ responseTooManyFailedAttempts: codexHttpStatusCodeSchema }).passthrough(),
+  z
+    .object({ activeTurnNotSteerable: z.object({ turnKind: z.string() }).passthrough() })
+    .passthrough(),
 ]);
 
 export const turnSchema = z
@@ -424,6 +491,8 @@ const toolRequestUserInputParamsSchema = z
   })
   .passthrough();
 
+// External contract: `skill/requestApproval` was removed from the codex
+// 0.142.5 server-request surface; kept for pre-0.142 servers.
 const skillRequestApprovalParamsSchema = z
   .object({
     itemId: z.string(),

--- a/src/app-server/protocol/validators.ts
+++ b/src/app-server/protocol/validators.ts
@@ -345,14 +345,14 @@ export const turnSchema = z
   .object({
     id: z.string(),
     items: z.array(threadItemSchema),
-    status: z.enum(['completed', 'interrupted', 'failed', 'inProgress']),
+    status: z.string(),
     error: z
       .object({
         message: z.string(),
-        codexErrorInfo: codexErrorInfoSchema.nullable(),
-        additionalDetails: z.string().nullable(),
+        codexErrorInfo: codexErrorInfoSchema.nullish(),
+        additionalDetails: z.string().nullish(),
       })
-      .nullable(),
+      .nullish(),
   })
   .passthrough();
 

--- a/src/app-server/provider.ts
+++ b/src/app-server/provider.ts
@@ -44,7 +44,7 @@ export interface CodexAppServerProvider extends ProviderV4 {
  * @example
  * ```ts
  * const provider = createCodexAppServer({
- *   defaultSettings: { minCodexVersion: '0.130.0' },
+ *   defaultSettings: { minCodexVersion: '0.142.5' },
  * });
  *
  * try {

--- a/src/app-server/provider.ts
+++ b/src/app-server/provider.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3, ProviderV3 } from '@ai-sdk/provider';
+import type { LanguageModelV4, ProviderV4 } from '@ai-sdk/provider';
 import { NoSuchModelError } from '@ai-sdk/provider';
 import { AppServerLanguageModel } from './language-model.js';
 import type { CodexAppServerProviderSettings, CodexAppServerSettings } from './types.js';
@@ -23,10 +23,10 @@ export interface CodexAppServerModelListResult {
  *
  * Use this via `createCodexAppServer()` or the default `codexAppServer` export.
  */
-export interface CodexAppServerProvider extends ProviderV3 {
-  (modelId: CodexModelId, settings?: CodexAppServerSettings): LanguageModelV3;
-  languageModel(modelId: CodexModelId, settings?: CodexAppServerSettings): LanguageModelV3;
-  chat(modelId: CodexModelId, settings?: CodexAppServerSettings): LanguageModelV3;
+export interface CodexAppServerProvider extends ProviderV4 {
+  (modelId: CodexModelId, settings?: CodexAppServerSettings): LanguageModelV4;
+  languageModel(modelId: CodexModelId, settings?: CodexAppServerSettings): LanguageModelV4;
+  chat(modelId: CodexModelId, settings?: CodexAppServerSettings): LanguageModelV4;
   embeddingModel(modelId: string): never;
   imageModel(modelId: string): never;
   close(): Promise<void>;
@@ -133,7 +133,7 @@ export function createCodexAppServer(
 
       return createModel(modelId, settings);
     },
-    { specificationVersion: 'v3' as const },
+    { specificationVersion: 'v4' as const },
   ) as unknown as CodexAppServerProvider;
 
   provider.languageModel = createModel;

--- a/src/app-server/rpc/client.ts
+++ b/src/app-server/rpc/client.ts
@@ -307,7 +307,7 @@ export class AppServerRpcClient extends EventEmitter {
     if (this.serverCapabilities?.modelList === false) {
       throw new UnsupportedFeatureError({
         feature: 'model/list',
-        minCodexVersion: this.settings.minCodexVersion ?? '0.130.0',
+        minCodexVersion: this.settings.minCodexVersion ?? '0.142.5',
         serverVersion: this.serverVersion,
       });
     }
@@ -321,7 +321,7 @@ export class AppServerRpcClient extends EventEmitter {
       if (error instanceof JsonRpcRequestError && error.code === -32601) {
         throw new UnsupportedFeatureError({
           feature: 'model/list',
-          minCodexVersion: this.settings.minCodexVersion ?? '0.130.0',
+          minCodexVersion: this.settings.minCodexVersion ?? '0.142.5',
           serverVersion: this.serverVersion,
         });
       }
@@ -512,7 +512,7 @@ export class AppServerRpcClient extends EventEmitter {
       const message = String((error as Error)?.message ?? error);
       if (message.includes('ENOENT') || message.includes('unknown subcommand')) {
         throw new Error(
-          "codex app-server requires codex CLI >= 0.130.0. Run 'codex --version' to check.",
+          "codex app-server requires codex CLI >= 0.142.5. Run 'codex --version' to check.",
         );
       }
 
@@ -538,7 +538,7 @@ export class AppServerRpcClient extends EventEmitter {
     }
 
     this.serverVersion = detected;
-    const minVersion = this.settings.minCodexVersion ?? '0.130.0';
+    const minVersion = this.settings.minCodexVersion ?? '0.142.5';
     const compared = compareSemver(detected, minVersion);
     if (compared === undefined) {
       this.logger.warn(

--- a/src/app-server/stream/emitter.ts
+++ b/src/app-server/stream/emitter.ts
@@ -1,10 +1,10 @@
 import type {
   JSONValue,
-  LanguageModelV3FinishReason,
-  LanguageModelV3StreamPart,
-  LanguageModelV3Usage,
-  SharedV3ProviderMetadata,
-  SharedV3Warning,
+  LanguageModelV4FinishReason,
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+  SharedV4ProviderMetadata,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import { generateId } from '@ai-sdk/provider-utils';
 
@@ -25,13 +25,13 @@ export class AppServerStreamEmitter {
   private closed = false;
 
   constructor(
-    private readonly controller: ReadableStreamDefaultController<LanguageModelV3StreamPart>,
+    private readonly controller: ReadableStreamDefaultController<LanguageModelV4StreamPart>,
     private readonly options: AppServerStreamEmitterOptions,
   ) {
     this.jsonModeLastTextBlockOnly = Boolean(options.jsonModeLastTextBlockOnly);
   }
 
-  private safeEnqueue(part: LanguageModelV3StreamPart): void {
+  private safeEnqueue(part: LanguageModelV4StreamPart): void {
     if (this.closed) return;
     try {
       this.controller.enqueue(part);
@@ -40,7 +40,7 @@ export class AppServerStreamEmitter {
     }
   }
 
-  emitStreamStart(warnings: SharedV3Warning[]): void {
+  emitStreamStart(warnings: SharedV4Warning[]): void {
     this.safeEnqueue({ type: 'stream-start', warnings });
   }
 
@@ -190,9 +190,9 @@ export class AppServerStreamEmitter {
   }
 
   emitFinish(
-    finishReason: LanguageModelV3FinishReason,
-    usage: LanguageModelV3Usage,
-    providerMetadata?: SharedV3ProviderMetadata,
+    finishReason: LanguageModelV4FinishReason,
+    usage: LanguageModelV4Usage,
+    providerMetadata?: SharedV4ProviderMetadata,
   ): void {
     if (this.jsonModeLastTextBlockOnly) {
       if (this.textId) {

--- a/src/app-server/stream/router-notification-handlers.ts
+++ b/src/app-server/stream/router-notification-handlers.ts
@@ -35,10 +35,24 @@ function mapTool(item: ThreadItem): { toolName: string; dynamic?: boolean } | un
     };
   }
 
+  if (type === 'dynamictoolcall') {
+    const tool = 'tool' in item && typeof item.tool === 'string' && item.tool ? item.tool : 'tool';
+    const namespace =
+      'namespace' in item && typeof item.namespace === 'string' && item.namespace
+        ? item.namespace
+        : undefined;
+    return {
+      toolName: namespace ? `${namespace}__${tool}` : tool,
+      dynamic: true,
+    };
+  }
+
   if (type === 'websearch') {
     return { toolName: 'web_search', dynamic: true };
   }
 
+  // hookPrompt, subAgentActivity, sleep, and imageGeneration items (plus any
+  // unknown future item types) are intentionally unmapped: raw chunks only for now.
   return undefined;
 }
 

--- a/src/app-server/stream/router-notification-handlers.ts
+++ b/src/app-server/stream/router-notification-handlers.ts
@@ -1,5 +1,5 @@
 import { generateId } from '@ai-sdk/provider-utils';
-import type { LanguageModelV3Usage } from '@ai-sdk/provider';
+import type { LanguageModelV4Usage } from '@ai-sdk/provider';
 import type { ThreadItem, ThreadTokenUsageUpdatedNotification, Turn } from '../protocol/types.js';
 import { safeStringify } from '../../shared-utils.js';
 import type { AppServerStreamEmitter } from './emitter.js';
@@ -47,7 +47,7 @@ export interface NotificationHandlerContext {
   toolTracker: ToolTracker;
   textItemIdsWithDelta: Set<string>;
   reasoningItemIdsWithDelta: Set<string>;
-  onUsage: (usage: LanguageModelV3Usage) => void;
+  onUsage: (usage: LanguageModelV4Usage) => void;
   onTurnCompleted: (turn: Turn) => void;
   onError: (error: Error) => void;
   isSameTurn: (params: Record<string, unknown>) => boolean;

--- a/src/app-server/stream/router.ts
+++ b/src/app-server/stream/router.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3Usage } from '@ai-sdk/provider';
+import type { LanguageModelV4Usage } from '@ai-sdk/provider';
 import type { Turn } from '../protocol/types.js';
 import { AppServerRpcClient } from '../rpc/client.js';
 import { AppServerStreamEmitter } from './emitter.js';
@@ -16,7 +16,7 @@ export interface AppServerNotificationRouterOptions {
   client: AppServerRpcClient;
   emitter: AppServerStreamEmitter;
   threadId: string;
-  onUsage: (usage: LanguageModelV3Usage) => void;
+  onUsage: (usage: LanguageModelV4Usage) => void;
   onThreadTurnCompleted?: (turn: Turn) => void;
   onTurnCompleted: (turn: Turn) => void;
   onError: (error: Error) => void;
@@ -35,7 +35,7 @@ export class AppServerNotificationRouter {
   private readonly client: AppServerRpcClient;
   private readonly emitter: AppServerStreamEmitter;
   private readonly threadId: string;
-  private readonly onUsage: (usage: LanguageModelV3Usage) => void;
+  private readonly onUsage: (usage: LanguageModelV4Usage) => void;
   private readonly onThreadTurnCompleted?: (turn: Turn) => void;
   private readonly onTurnCompleted: (turn: Turn) => void;
   private readonly onError: (error: Error) => void;

--- a/src/app-server/stream/turn-stream-controller.ts
+++ b/src/app-server/stream/turn-stream-controller.ts
@@ -1,7 +1,7 @@
 import type {
-  LanguageModelV3StreamPart,
-  LanguageModelV3Usage,
-  SharedV3Warning,
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import { createEmptyCodexUsage, sanitizeJsonSchema } from '../../shared-utils.js';
 import type { Turn, TurnStartParams } from '../protocol/types.js';
@@ -87,7 +87,7 @@ export interface TurnStreamControllerOptions {
   client: AppServerRpcClient;
   modelId: string;
   threadId: string;
-  warnings: SharedV3Warning[];
+  warnings: SharedV4Warning[];
   includeRawChunks: boolean;
   jsonModeLastTextBlockOnly: boolean;
   turnStartParams: TurnStartParams;
@@ -107,7 +107,7 @@ export interface TurnStreamControllerOptions {
 
 export class TurnStreamController {
   private state: TurnStreamState = 'created';
-  private usage: LanguageModelV3Usage = createEmptyCodexUsage();
+  private usage: LanguageModelV4Usage = createEmptyCodexUsage();
   private turnId?: string;
   private requestContextId?: string;
   private cleanedUp = false;
@@ -139,7 +139,7 @@ export class TurnStreamController {
   }
 
   async start(
-    controller: ReadableStreamDefaultController<LanguageModelV3StreamPart>,
+    controller: ReadableStreamDefaultController<LanguageModelV4StreamPart>,
   ): Promise<void> {
     if (this.state !== 'created') {
       return;

--- a/src/converters/image-converter.ts
+++ b/src/converters/image-converter.ts
@@ -1,4 +1,5 @@
-import type { LanguageModelV3FilePart } from '@ai-sdk/provider';
+import type { LanguageModelV4FilePart, SharedV4FileData } from '@ai-sdk/provider';
+import { getTopLevelMediaType } from '@ai-sdk/provider-utils';
 import { extractImageData, type ImageData } from '../image-utils.js';
 import type { CompatImagePart, PromptContentPart } from './types.js';
 
@@ -30,15 +31,29 @@ function asRemoteUrl(value: unknown): string | undefined {
 }
 
 export function isImageMediaType(mediaType: string): boolean {
-  return mediaType.toLowerCase().startsWith('image/');
+  return getTopLevelMediaType(mediaType).toLowerCase() === 'image';
 }
 
-export function isFilePart(part: PromptContentPart): part is LanguageModelV3FilePart {
-  return part.type === 'file' && typeof (part as { mediaType?: unknown }).mediaType === 'string';
+export function isFilePart(part: PromptContentPart): part is LanguageModelV4FilePart {
+  return part.type === 'file' && 'mediaType' in part && typeof part.mediaType === 'string';
 }
 
 export function isCompatImagePart(part: PromptContentPart): part is CompatImagePart {
   return part.type === 'image';
+}
+
+/**
+ * Narrow a value to the v4 tagged file-data union
+ * ({ type: 'data' | 'url' | 'reference' | 'text', ... }).
+ */
+function isTaggedFileData(value: unknown): value is SharedV4FileData {
+  if (typeof value !== 'object' || value === null || !('type' in value)) return false;
+  return (
+    value.type === 'data' ||
+    value.type === 'url' ||
+    value.type === 'reference' ||
+    value.type === 'text'
+  );
 }
 
 export function toImageReference(
@@ -56,7 +71,51 @@ export function toImageReference(
       };
     }
 
-    const remote = asRemoteUrl(part.data);
+    const data: unknown = part.data;
+
+    if (isTaggedFileData(data)) {
+      if (data.type === 'reference') {
+        return {
+          kind: 'unsupported',
+          warning: 'File reference data is not supported for images.',
+        };
+      }
+
+      if (data.type === 'text') {
+        return {
+          kind: 'unsupported',
+          warning: 'Inline text file data is not supported for images.',
+        };
+      }
+
+      if (data.type === 'url') {
+        const remote = asRemoteUrl(data.url);
+        if (remote) {
+          return { kind: 'remote', url: remote };
+        }
+
+        if (isFileUrlValue(data.url)) {
+          return {
+            kind: 'unsupported',
+            warning: 'file:// image URLs are not supported.',
+          };
+        }
+      }
+
+      // 'data' variants and data: URLs are extracted to local images.
+      const image = extractImageData(part);
+      if (image) {
+        return { kind: 'local', image };
+      }
+
+      return {
+        kind: 'unsupported',
+        warning: 'Unsupported image format in message.',
+      };
+    }
+
+    // Legacy untagged data (compat with user-facing message shapes).
+    const remote = asRemoteUrl(data);
     if (remote) {
       return { kind: 'remote', url: remote };
     }
@@ -66,7 +125,7 @@ export function toImageReference(
       return { kind: 'local', image };
     }
 
-    if (isFileUrlValue(part.data) || isFileUrlValue((part as { url?: unknown }).url)) {
+    if (isFileUrlValue(data) || ('url' in part && isFileUrlValue(part.url))) {
       return {
         kind: 'unsupported',
         warning: 'file:// image URLs are not supported.',
@@ -90,11 +149,7 @@ export function toImageReference(
       return { kind: 'local', image };
     }
 
-    if (
-      isFileUrlValue(part.image) ||
-      isFileUrlValue(part.url) ||
-      isFileUrlValue((part as { data?: unknown }).data)
-    ) {
+    if (isFileUrlValue(part.image) || isFileUrlValue(part.url) || isFileUrlValue(part.data)) {
       return {
         kind: 'unsupported',
         warning: 'file:// image URLs are not supported.',

--- a/src/converters/index.ts
+++ b/src/converters/index.ts
@@ -1,4 +1,4 @@
-export { convertPromptToCodexInput } from './prompt-converter.js';
+export { collectSystemInstruction, convertPromptToCodexInput } from './prompt-converter.js';
 export { formatToolResultOutput, safeJsonStringify } from './tool-result-converter.js';
 export { isImageMediaType, toImageReference } from './image-converter.js';
 export type { ConvertedPrompt, PromptConversionMode, PromptMessage } from './types.js';

--- a/src/converters/prompt-converter.ts
+++ b/src/converters/prompt-converter.ts
@@ -197,6 +197,25 @@ function formatAssistantParts(parts: PromptContentPart[]): {
       continue;
     }
 
+    if (part.type === 'custom') {
+      const kind = 'kind' in part && typeof part.kind === 'string' ? part.kind : undefined;
+      warnings.push({
+        type: 'unsupported',
+        feature: 'prompt.assistant.custom',
+        details: `Custom content parts are not supported${kind ? ` (kind "${kind}")` : ''}.`,
+      });
+      continue;
+    }
+
+    if (part.type === 'reasoning-file') {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'prompt.assistant.reasoning-file',
+        details: 'Reasoning file parts are not supported.',
+      });
+      continue;
+    }
+
     warnings.push({
       type: 'unsupported',
       feature: `prompt.assistant.${part.type}`,

--- a/src/converters/prompt-converter.ts
+++ b/src/converters/prompt-converter.ts
@@ -52,7 +52,7 @@ function isToolApprovalResponsePart(part: PromptContentPart): part is {
   );
 }
 
-function collectSystemInstruction(prompt: readonly PromptMessage[]): string | undefined {
+export function collectSystemInstruction(prompt: readonly PromptMessage[]): string | undefined {
   const parts: string[] = [];
 
   for (const message of prompt) {

--- a/src/converters/tool-result-converter.ts
+++ b/src/converters/tool-result-converter.ts
@@ -1,4 +1,5 @@
 import type { ConvertedToolResult, ConvertedWarning, NormalizedToolOutput } from './types.js';
+import { isImageMediaType } from './image-converter.js';
 
 export function safeJsonStringify(value: unknown): string {
   if (value === undefined) return '';
@@ -9,6 +10,17 @@ export function safeJsonStringify(value: unknown): string {
   } catch {
     return '[unserializable]';
   }
+}
+
+/**
+ * Describe the `type` tag of a runtime value that fell outside the static
+ * union (used for warnings about unrecognized parts).
+ */
+function describeTypeTag(value: unknown): string {
+  if (typeof value === 'object' && value !== null && 'type' in value) {
+    return String(value.type);
+  }
+  return 'unknown';
 }
 
 export function formatToolResultOutput(output: NormalizedToolOutput): ConvertedToolResult {
@@ -31,19 +43,42 @@ export function formatToolResultOutput(output: NormalizedToolOutput): ConvertedT
       const parts = output.value
         .map((part) => {
           if (part.type === 'text') return part.text;
-          if (part.type === 'file-data') {
-            return `[file-data: ${part.mediaType}${part.filename ? `, ${part.filename}` : ''}]`;
+
+          if (part.type === 'file') {
+            const prefix = isImageMediaType(part.mediaType) ? 'image' : 'file';
+            const data = part.data;
+            if (data.type === 'data') {
+              return prefix === 'image'
+                ? `[image-data: ${part.mediaType}]`
+                : `[file-data: ${part.mediaType}${part.filename ? `, ${part.filename}` : ''}]`;
+            }
+            if (data.type === 'url') return `[${prefix}-url: ${data.url}]`;
+            if (data.type === 'reference') {
+              return prefix === 'image' ? '[image-file-id]' : '[file-id]';
+            }
+            if (data.type === 'text') return data.text;
+
+            warnings.push({
+              type: 'unsupported',
+              feature: 'tool-result.content.file',
+              details: `Unsupported tool file content data type "${describeTypeTag(data)}".`,
+            });
+            return '[unsupported-tool-content-part]';
           }
-          if (part.type === 'file-url') return `[file-url: ${part.url}]`;
-          if (part.type === 'file-id') return '[file-id]';
-          if (part.type === 'image-data') return `[image-data: ${part.mediaType}]`;
-          if (part.type === 'image-url') return `[image-url: ${part.url}]`;
-          if (part.type === 'image-file-id') return '[image-file-id]';
+
+          if (part.type === 'custom') {
+            warnings.push({
+              type: 'unsupported',
+              feature: 'tool-result.content.custom',
+              details: 'Custom tool content parts are not supported.',
+            });
+            return '';
+          }
 
           warnings.push({
             type: 'unsupported',
-            feature: `tool-result.content.${String((part as { type?: unknown }).type)}`,
-            details: `Unsupported tool content part "${String((part as { type?: unknown }).type)}".`,
+            feature: `tool-result.content.${describeTypeTag(part)}`,
+            details: `Unsupported tool content part "${describeTypeTag(part)}".`,
           });
           return '[unsupported-tool-content-part]';
         })
@@ -57,8 +92,8 @@ export function formatToolResultOutput(output: NormalizedToolOutput): ConvertedT
         warnings: [
           {
             type: 'unsupported',
-            feature: `tool-result.output.${String((output as { type?: unknown }).type)}`,
-            details: `Unsupported tool result output type "${String((output as { type?: unknown }).type)}".`,
+            feature: `tool-result.output.${describeTypeTag(output)}`,
+            details: `Unsupported tool result output type "${describeTypeTag(output)}".`,
           },
         ],
       };

--- a/src/converters/types.ts
+++ b/src/converters/types.ts
@@ -1,11 +1,11 @@
 import type {
-  LanguageModelV3DataContent,
-  LanguageModelV3FilePart,
-  LanguageModelV3Message,
-  LanguageModelV3ToolApprovalResponsePart,
-  LanguageModelV3ToolCallPart,
-  LanguageModelV3ToolResultOutput,
-  LanguageModelV3ToolResultPart,
+  LanguageModelV4FilePart,
+  LanguageModelV4Message,
+  LanguageModelV4ToolApprovalResponsePart,
+  LanguageModelV4ToolCallPart,
+  LanguageModelV4ToolResultOutput,
+  LanguageModelV4ToolResultPart,
+  SharedV4FileData,
 } from '@ai-sdk/provider';
 import type { ImageData } from '../image-utils.js';
 
@@ -21,15 +21,15 @@ export interface CompatImagePart {
 
 export type PromptContentPart =
   | { type: 'text'; text: string }
-  | LanguageModelV3FilePart
+  | LanguageModelV4FilePart
   | CompatImagePart
   | { type: 'reasoning'; text: string }
-  | LanguageModelV3ToolCallPart
-  | LanguageModelV3ToolResultPart
-  | LanguageModelV3ToolApprovalResponsePart
+  | LanguageModelV4ToolCallPart
+  | LanguageModelV4ToolResultPart
+  | LanguageModelV4ToolApprovalResponsePart
   | { type: string; [key: string]: unknown };
 
-export type PromptMessage = Omit<LanguageModelV3Message, 'content'> & {
+export type PromptMessage = Omit<LanguageModelV4Message, 'content'> & {
   content: string | PromptContentPart[];
 };
 
@@ -57,6 +57,6 @@ export interface ConvertedToolResult {
   warnings: ConvertedWarning[];
 }
 
-export type NormalizedToolOutput = LanguageModelV3ToolResultOutput;
+export type NormalizedToolOutput = LanguageModelV4ToolResultOutput;
 
-export type FileData = LanguageModelV3DataContent;
+export type FileData = SharedV4FileData;

--- a/src/exec-language-model.ts
+++ b/src/exec-language-model.ts
@@ -7,22 +7,22 @@ import { dirname, join } from 'node:path';
 import type { ReadableStreamDefaultController } from 'node:stream/web';
 import { z } from 'zod';
 import type {
-  LanguageModelV3,
-  LanguageModelV3File,
-  LanguageModelV3FinishReason,
-  LanguageModelV3Reasoning,
-  LanguageModelV3ResponseMetadata,
-  LanguageModelV3Source,
-  LanguageModelV3StreamPart,
-  LanguageModelV3Text,
-  LanguageModelV3ToolApprovalRequest,
-  LanguageModelV3ToolCall,
-  LanguageModelV3ToolResult,
-  LanguageModelV3Usage,
-  LanguageModelV3Content,
+  LanguageModelV4,
+  LanguageModelV4File,
+  LanguageModelV4FinishReason,
+  LanguageModelV4Reasoning,
+  LanguageModelV4ResponseMetadata,
+  LanguageModelV4Source,
+  LanguageModelV4StreamPart,
+  LanguageModelV4Text,
+  LanguageModelV4ToolApprovalRequest,
+  LanguageModelV4ToolCall,
+  LanguageModelV4ToolResult,
+  LanguageModelV4Usage,
+  LanguageModelV4Content,
   JSONObject,
-  SharedV3ProviderMetadata,
-  SharedV3Warning,
+  SharedV4ProviderMetadata,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import { NoSuchModelError } from '@ai-sdk/provider';
 import { generateId, parseProviderOptions } from '@ai-sdk/provider-utils';
@@ -47,7 +47,7 @@ import {
   safeStringify,
   sanitizeJsonSchema,
 } from './shared-utils.js';
-import type { CodexModelId } from './types-shared.js';
+import type { CodexModelId, ReasoningEffort } from './types-shared.js';
 
 export interface ExecLanguageModelOptions {
   id: CodexModelId; // model id for Codex (-m)
@@ -86,6 +86,16 @@ interface ActiveToolItem {
   inputPayload?: unknown;
   hasEmittedCall: boolean;
 }
+
+// Codex reasoning effort levels; kept in compile-time sync with ReasoningEffort.
+const codexReasoningEfforts: Record<ReasoningEffort, true> = {
+  none: true,
+  minimal: true,
+  low: true,
+  medium: true,
+  high: true,
+  xhigh: true,
+};
 
 const codexCliProviderOptionsSchema: z.ZodType<CodexExecProviderOptions> = z
   .object({
@@ -139,13 +149,10 @@ function resolveCodexPath(
   }
 }
 
-export class ExecLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = 'v3' as const;
+export class ExecLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4' as const;
   readonly provider = 'codex-cli';
-  readonly defaultObjectGenerationMode = 'json' as const;
-  readonly supportsImageUrls = false;
   readonly supportedUrls = {};
-  readonly supportsStructuredOutputs = true;
 
   readonly modelId: string;
   readonly settings: CodexExecSettings;
@@ -471,7 +478,7 @@ export class ExecLanguageModel implements LanguageModelV3 {
     }
   }
 
-  private extractUsage(evt: ExperimentalJsonEvent): LanguageModelV3Usage | undefined {
+  private extractUsage(evt: ExperimentalJsonEvent): LanguageModelV4Usage | undefined {
     const reported = evt.usage;
     if (!reported) return undefined;
     const inputTotal = reported.input_tokens ?? 0;
@@ -610,7 +617,7 @@ export class ExecLanguageModel implements LanguageModelV3 {
   }
 
   private emitToolInvocation(
-    controller: ReadableStreamDefaultController<LanguageModelV3StreamPart>,
+    controller: ReadableStreamDefaultController<LanguageModelV4StreamPart>,
     toolCallId: string,
     toolName: string,
     inputPayload: unknown,
@@ -638,7 +645,7 @@ export class ExecLanguageModel implements LanguageModelV3 {
   }
 
   private emitToolResult(
-    controller: ReadableStreamDefaultController<LanguageModelV3StreamPart>,
+    controller: ReadableStreamDefaultController<LanguageModelV4StreamPart>,
     toolCallId: string,
     toolName: string,
     item: ExperimentalJsonItem,
@@ -705,40 +712,40 @@ export class ExecLanguageModel implements LanguageModelV3 {
   }
 
   async doGenerate(
-    options: Parameters<LanguageModelV3['doGenerate']>[0],
-  ): Promise<Awaited<ReturnType<LanguageModelV3['doGenerate']>>> {
+    options: Parameters<LanguageModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<LanguageModelV4['doGenerate']>>> {
     this.logger.debug(`[codex-cli] Starting doGenerate request with model: ${this.modelId}`);
 
     const { stream, request } = await this.doStream(
-      options as Parameters<LanguageModelV3['doStream']>[0],
+      options as Parameters<LanguageModelV4['doStream']>[0],
     );
 
-    const content: LanguageModelV3Content[] = [];
-    const textPartsById = new Map<string, LanguageModelV3Text>();
-    const reasoningPartsById = new Map<string, LanguageModelV3Reasoning>();
+    const content: LanguageModelV4Content[] = [];
+    const textPartsById = new Map<string, LanguageModelV4Text>();
+    const reasoningPartsById = new Map<string, LanguageModelV4Reasoning>();
     let activeTextBlockId: string | undefined;
     let activeReasoningBlockId: string | undefined;
-    let responseMetadata: LanguageModelV3ResponseMetadata = {
+    let responseMetadata: LanguageModelV4ResponseMetadata = {
       id: generateId(),
       timestamp: new Date(),
       modelId: this.modelId,
     };
-    let usage: LanguageModelV3Usage = createEmptyCodexUsage();
-    let finishReason: LanguageModelV3FinishReason = { unified: 'other', raw: undefined };
-    let warnings: SharedV3Warning[] = [];
-    let providerMetadata: SharedV3ProviderMetadata | undefined;
+    let usage: LanguageModelV4Usage = createEmptyCodexUsage();
+    let finishReason: LanguageModelV4FinishReason = { unified: 'other', raw: undefined };
+    let warnings: SharedV4Warning[] = [];
+    let providerMetadata: SharedV4ProviderMetadata | undefined;
 
     const ensureTextPart = (
       id: string,
-      metadata?: SharedV3ProviderMetadata,
-    ): LanguageModelV3Text => {
+      metadata?: SharedV4ProviderMetadata,
+    ): LanguageModelV4Text => {
       const existing = textPartsById.get(id);
       if (existing) {
         if (metadata) existing.providerMetadata = metadata;
         return existing;
       }
 
-      const part: LanguageModelV3Text = {
+      const part: LanguageModelV4Text = {
         type: 'text',
         text: '',
         ...(metadata ? { providerMetadata: metadata } : {}),
@@ -750,15 +757,15 @@ export class ExecLanguageModel implements LanguageModelV3 {
 
     const ensureReasoningPart = (
       id: string,
-      metadata?: SharedV3ProviderMetadata,
-    ): LanguageModelV3Reasoning => {
+      metadata?: SharedV4ProviderMetadata,
+    ): LanguageModelV4Reasoning => {
       const existing = reasoningPartsById.get(id);
       if (existing) {
         if (metadata) existing.providerMetadata = metadata;
         return existing;
       }
 
-      const part: LanguageModelV3Reasoning = {
+      const part: LanguageModelV4Reasoning = {
         type: 'reasoning',
         text: '',
         ...(metadata ? { providerMetadata: metadata } : {}),
@@ -770,16 +777,16 @@ export class ExecLanguageModel implements LanguageModelV3 {
 
     const pushContentPart = (
       part:
-        | LanguageModelV3File
-        | LanguageModelV3Source
-        | LanguageModelV3ToolApprovalRequest
-        | LanguageModelV3ToolCall
-        | LanguageModelV3ToolResult,
+        | LanguageModelV4File
+        | LanguageModelV4Source
+        | LanguageModelV4ToolApprovalRequest
+        | LanguageModelV4ToolCall
+        | LanguageModelV4ToolResult,
     ): void => {
       content.push(part);
     };
 
-    for await (const part of stream as AsyncIterable<LanguageModelV3StreamPart>) {
+    for await (const part of stream as AsyncIterable<LanguageModelV4StreamPart>) {
       if (part.type === 'stream-start') {
         warnings = part.warnings;
         continue;
@@ -895,7 +902,7 @@ export class ExecLanguageModel implements LanguageModelV3 {
     const codexProviderMetadata =
       providerMetadata && typeof providerMetadata === 'object'
         ? { ...providerMetadata }
-        : ({} as SharedV3ProviderMetadata);
+        : ({} as SharedV4ProviderMetadata);
 
     if (this.sessionId) {
       const existing = codexProviderMetadata['codex-cli'];
@@ -923,8 +930,8 @@ export class ExecLanguageModel implements LanguageModelV3 {
   }
 
   async doStream(
-    options: Parameters<LanguageModelV3['doStream']>[0],
-  ): Promise<Awaited<ReturnType<LanguageModelV3['doStream']>>> {
+    options: Parameters<LanguageModelV4['doStream']>[0],
+  ): Promise<Awaited<ReturnType<LanguageModelV4['doStream']>>> {
     this.logger.debug(`[codex-cli] Starting doStream request with model: ${this.modelId}`);
 
     const { promptText, images, warnings: mappingWarnings } = mapMessagesToPrompt(options.prompt);
@@ -943,7 +950,7 @@ export class ExecLanguageModel implements LanguageModelV3 {
         toolChoice: (options as { toolChoice?: unknown }).toolChoice,
       }),
       ...(mappingWarnings ?? []),
-    ] as SharedV3Warning[];
+    ] as SharedV4Warning[];
 
     this.logger.debug(
       `[codex-cli] Converted ${options.prompt.length} messages (${images.length} images) for streaming, response format: ${options.responseFormat?.type ?? 'none'}`,
@@ -954,7 +961,30 @@ export class ExecLanguageModel implements LanguageModelV3 {
       providerOptions: options.providerOptions,
       schema: codexCliProviderOptionsSchema,
     });
-    const effectiveSettings = this.mergeSettings(providerOptions);
+    let effectiveSettings = this.mergeSettings(providerOptions);
+
+    // Map the top-level v4 `reasoning` call option to Codex reasoning effort.
+    // The provider-specific option wins when present; 'provider-default' and
+    // undefined leave the existing default behavior untouched.
+    const topLevelReasoning = options.reasoning;
+    if (
+      topLevelReasoning !== undefined &&
+      topLevelReasoning !== 'provider-default' &&
+      providerOptions?.reasoningEffort === undefined
+    ) {
+      if (Object.hasOwn(codexReasoningEfforts, topLevelReasoning)) {
+        effectiveSettings = {
+          ...effectiveSettings,
+          reasoningEffort: topLevelReasoning,
+        };
+      } else {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'reasoning',
+          details: `Codex CLI does not support reasoning effort '${topLevelReasoning}'; it will be ignored.`,
+        });
+      }
+    }
 
     const responseFormat =
       options.responseFormat?.type === 'json'
@@ -967,7 +997,7 @@ export class ExecLanguageModel implements LanguageModelV3 {
       `[codex-cli] Executing Codex CLI for streaming: ${cmd} with ${args.length} arguments`,
     );
 
-    const stream = new ReadableStream<LanguageModelV3StreamPart>({
+    const stream = new ReadableStream<LanguageModelV4StreamPart>({
       start: (controller) => {
         const startTime = Date.now();
         // Use stdin to pass prompt - avoids command line length limits and escaping issues on Windows
@@ -984,7 +1014,7 @@ export class ExecLanguageModel implements LanguageModelV3 {
         let accumulatedText = '';
         const activeTools = new Map<string, ActiveToolItem>();
         let responseMetadataSent = false;
-        let lastUsage: LanguageModelV3Usage | undefined;
+        let lastUsage: LanguageModelV4Usage | undefined;
         let turnFailureMessage: string | undefined;
 
         // Define cleanup early so it's available for early abort
@@ -1149,7 +1179,7 @@ export class ExecLanguageModel implements LanguageModelV3 {
             controller.enqueue({ type: 'text-end', id: textId });
           }
 
-          const usageSummary: LanguageModelV3Usage = lastUsage ?? createEmptyCodexUsage();
+          const usageSummary: LanguageModelV4Usage = lastUsage ?? createEmptyCodexUsage();
           const totalTokens =
             (usageSummary.inputTokens.total ?? 0) + (usageSummary.outputTokens.total ?? 0);
           this.logger.info(
@@ -1249,7 +1279,7 @@ export class ExecLanguageModel implements LanguageModelV3 {
     });
 
     return { stream, request: { body: promptText } } as Awaited<
-      ReturnType<LanguageModelV3['doStream']>
+      ReturnType<LanguageModelV4['doStream']>
     >;
   }
 }

--- a/src/exec-language-model.ts
+++ b/src/exec-language-model.ts
@@ -1012,6 +1012,7 @@ export class ExecLanguageModel implements LanguageModelV4 {
 
         let stderr = '';
         let accumulatedText = '';
+        let stdoutBuffer = '';
         const activeTools = new Map<string, ActiveToolItem>();
         let responseMetadataSent = false;
         let lastUsage: LanguageModelV4Usage | undefined;
@@ -1196,66 +1197,74 @@ export class ExecLanguageModel implements LanguageModelV4 {
           controller.close();
         };
 
+        const processLine = (line: string) => {
+          const event = this.parseExperimentalJsonEvent(line);
+          if (!event) return;
+
+          this.logger.debug(`[codex-cli] Stream event: ${event.type ?? 'unknown'}`);
+
+          if (event.type === 'thread.started' && typeof event.thread_id === 'string') {
+            this.sessionId = event.thread_id;
+            this.logger.debug(`[codex-cli] Stream session started: ${this.sessionId}`);
+            if (!responseMetadataSent) {
+              responseMetadataSent = true;
+              sendMetadata();
+            }
+            return;
+          }
+
+          if (event.type === 'session.created' && typeof event.session_id === 'string') {
+            this.sessionId = event.session_id;
+            this.logger.debug(`[codex-cli] Stream session created: ${this.sessionId}`);
+            if (!responseMetadataSent) {
+              responseMetadataSent = true;
+              sendMetadata();
+            }
+            return;
+          }
+
+          if (event.type === 'turn.completed') {
+            const usageEvent = this.extractUsage(event);
+            if (usageEvent) {
+              lastUsage = usageEvent;
+            }
+            return;
+          }
+
+          if (event.type === 'turn.failed') {
+            const errorText =
+              (event.error && typeof event.error.message === 'string' && event.error.message) ||
+              (typeof event.message === 'string' ? event.message : undefined);
+            turnFailureMessage = errorText ?? turnFailureMessage ?? 'Codex turn failed';
+            this.logger.error(`[codex-cli] Stream turn failed: ${turnFailureMessage}`);
+            sendMetadata({ error: turnFailureMessage });
+            return;
+          }
+
+          if (event.type === 'error') {
+            const errorText = typeof event.message === 'string' ? event.message : undefined;
+            const effective = errorText ?? 'Codex error';
+            turnFailureMessage = turnFailureMessage ?? effective;
+            this.logger.error(`[codex-cli] Stream error event: ${effective}`);
+            sendMetadata({ error: effective });
+            return;
+          }
+
+          if (event.type && event.type.startsWith('item.')) {
+            handleItemEvent(event);
+          }
+        };
+
         child.stderr.on('data', (d) => (stderr += String(d)));
         child.stdout.setEncoding('utf8');
         child.stdout.on('data', (chunk: string) => {
-          const lines = chunk.split(/\r?\n/).filter(Boolean);
-          for (const line of lines) {
-            const event = this.parseExperimentalJsonEvent(line);
-            if (!event) continue;
-
-            this.logger.debug(`[codex-cli] Stream event: ${event.type ?? 'unknown'}`);
-
-            if (event.type === 'thread.started' && typeof event.thread_id === 'string') {
-              this.sessionId = event.thread_id;
-              this.logger.debug(`[codex-cli] Stream session started: ${this.sessionId}`);
-              if (!responseMetadataSent) {
-                responseMetadataSent = true;
-                sendMetadata();
-              }
-              continue;
-            }
-
-            if (event.type === 'session.created' && typeof event.session_id === 'string') {
-              this.sessionId = event.session_id;
-              this.logger.debug(`[codex-cli] Stream session created: ${this.sessionId}`);
-              if (!responseMetadataSent) {
-                responseMetadataSent = true;
-                sendMetadata();
-              }
-              continue;
-            }
-
-            if (event.type === 'turn.completed') {
-              const usageEvent = this.extractUsage(event);
-              if (usageEvent) {
-                lastUsage = usageEvent;
-              }
-              continue;
-            }
-
-            if (event.type === 'turn.failed') {
-              const errorText =
-                (event.error && typeof event.error.message === 'string' && event.error.message) ||
-                (typeof event.message === 'string' ? event.message : undefined);
-              turnFailureMessage = errorText ?? turnFailureMessage ?? 'Codex turn failed';
-              this.logger.error(`[codex-cli] Stream turn failed: ${turnFailureMessage}`);
-              sendMetadata({ error: turnFailureMessage });
-              continue;
-            }
-
-            if (event.type === 'error') {
-              const errorText = typeof event.message === 'string' ? event.message : undefined;
-              const effective = errorText ?? 'Codex error';
-              turnFailureMessage = turnFailureMessage ?? effective;
-              this.logger.error(`[codex-cli] Stream error event: ${effective}`);
-              sendMetadata({ error: effective });
-              continue;
-            }
-
-            if (event.type && event.type.startsWith('item.')) {
-              handleItemEvent(event);
-            }
+          // Carry incomplete trailing lines across data events so JSONL split
+          // across OS pipe chunks is reassembled before parse.
+          const pieces = (stdoutBuffer + chunk).split(/\r?\n/);
+          stdoutBuffer = pieces.pop() ?? '';
+          for (const line of pieces) {
+            if (!line) continue;
+            processLine(line);
           }
         });
 
@@ -1272,7 +1281,14 @@ export class ExecLanguageModel implements LanguageModelV4 {
           cleanupTempFiles();
 
           // Use setImmediate to ensure all stdout 'data' events are processed first
-          setImmediate(() => finishStream(code));
+          setImmediate(() => {
+            // Flush any final JSONL line that arrived without a trailing newline
+            if (stdoutBuffer) {
+              processLine(stdoutBuffer);
+              stdoutBuffer = '';
+            }
+            finishStream(code);
+          });
         });
       },
       cancel: () => {},

--- a/src/exec-provider.ts
+++ b/src/exec-provider.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3, ProviderV3 } from '@ai-sdk/provider';
+import type { LanguageModelV4, ProviderV4 } from '@ai-sdk/provider';
 import { NoSuchModelError } from '@ai-sdk/provider';
 import { ExecLanguageModel } from './exec-language-model.js';
 import type { CodexExecProviderSettings, CodexExecSettings } from './types.js';
@@ -6,10 +6,10 @@ import { getLogger } from './logger.js';
 import { validateExecSettings } from './validation.js';
 import type { CodexModelId } from './types-shared.js';
 
-export interface CodexExecProvider extends ProviderV3 {
-  (modelId: CodexModelId, settings?: CodexExecSettings): LanguageModelV3;
-  languageModel(modelId: CodexModelId, settings?: CodexExecSettings): LanguageModelV3;
-  chat(modelId: CodexModelId, settings?: CodexExecSettings): LanguageModelV3;
+export interface CodexExecProvider extends ProviderV4 {
+  (modelId: CodexModelId, settings?: CodexExecSettings): LanguageModelV4;
+  languageModel(modelId: CodexModelId, settings?: CodexExecSettings): LanguageModelV4;
+  chat(modelId: CodexModelId, settings?: CodexExecSettings): LanguageModelV4;
   embeddingModel(modelId: string): never;
   imageModel(modelId: string): never;
 }
@@ -28,7 +28,7 @@ export function createCodexExec(options: CodexExecProviderSettings = {}): CodexE
   const createModel = (
     modelId: CodexModelId,
     settings: CodexExecSettings = {},
-  ): LanguageModelV3 => {
+  ): LanguageModelV4 => {
     const merged: CodexExecSettings = { ...options.defaultSettings, ...settings };
     const v = validateExecSettings(merged);
     if (!v.valid) throw new Error(`Invalid settings: ${v.errors.join(', ')}`);
@@ -41,7 +41,7 @@ export function createCodexExec(options: CodexExecProviderSettings = {}): CodexE
       if (new.target) throw new Error('The Codex CLI provider function cannot be called with new.');
       return createModel(modelId, settings);
     },
-    { specificationVersion: 'v3' as const },
+    { specificationVersion: 'v4' as const },
   ) as CodexExecProvider;
 
   provider.languageModel = createModel;

--- a/src/image-utils.ts
+++ b/src/image-utils.ts
@@ -1,6 +1,8 @@
 import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { SharedV4FileData } from '@ai-sdk/provider';
+import { detectMediaType, getTopLevelMediaType, isFullMediaType } from '@ai-sdk/provider-utils';
 
 /**
  * Image data extracted from AI SDK image parts.
@@ -30,13 +32,54 @@ export interface ImagePart {
 }
 
 /**
- * AI SDK v6 file part structure used for binary/image inputs.
+ * AI SDK file part structure used for binary/image inputs.
+ * `data` accepts both the v4 tagged union and legacy untagged values.
  */
 export interface FilePart {
   type: 'file';
-  data?: string | URL | Buffer | ArrayBuffer | Uint8Array;
+  data?: string | URL | Buffer | ArrayBuffer | Uint8Array | SharedV4FileData;
   mediaType?: string;
   url?: string;
+}
+
+/**
+ * Narrow a value to the v4 tagged file-data union
+ * ({ type: 'data' | 'url' | 'reference' | 'text', ... }).
+ */
+function isTaggedFileData(value: unknown): value is SharedV4FileData {
+  if (typeof value !== 'object' || value === null || !('type' in value)) return false;
+  return (
+    value.type === 'data' ||
+    value.type === 'url' ||
+    value.type === 'reference' ||
+    value.type === 'text'
+  );
+}
+
+/**
+ * Resolve a full image MIME type from a declared media type that may be a
+ * top-level segment (e.g. `image`) or a wildcard (e.g. `image/*`), sniffing
+ * the data when possible.
+ */
+function resolveImageMimeType(declaredType: string, data: unknown): string {
+  if (isFullMediaType(declaredType)) return declaredType;
+
+  const bytes =
+    typeof data === 'string' || data instanceof Uint8Array
+      ? data
+      : data instanceof ArrayBuffer
+        ? new Uint8Array(data)
+        : undefined;
+
+  if (bytes !== undefined) {
+    const detected = detectMediaType({
+      data: bytes,
+      topLevelType: getTopLevelMediaType(declaredType),
+    });
+    if (detected) return detected;
+  }
+
+  return 'image/png';
 }
 
 /**
@@ -51,13 +94,27 @@ export function extractImageData(part: unknown): ImageData | null {
 
   const p = part as ImagePart | FilePart;
   const isFilePart = p.type === 'file';
-  const mimeType = isFilePart ? p.mediaType || 'image/png' : p.mimeType || 'image/png';
+  const declaredType = isFilePart ? p.mediaType || 'image/png' : p.mimeType || 'image/png';
 
-  if (isFilePart && !mimeType.toLowerCase().startsWith('image/')) {
+  if (isFilePart && getTopLevelMediaType(declaredType).toLowerCase() !== 'image') {
     return null;
   }
 
-  const primaryInput = isFilePart ? p.data : p.image;
+  let primaryInput = isFilePart ? p.data : p.image;
+
+  // Unwrap AI SDK v4 tagged file data.
+  if (isTaggedFileData(primaryInput)) {
+    if (primaryInput.type === 'data') {
+      primaryInput = primaryInput.data;
+    } else if (primaryInput.type === 'url') {
+      primaryInput = primaryInput.url;
+    } else {
+      // 'reference' and 'text' file data carry no image bytes.
+      return null;
+    }
+  }
+
+  const mimeType = resolveImageMimeType(declaredType, primaryInput);
 
   // Case 1: Primary image/file field is a string
   if (typeof primaryInput === 'string') {

--- a/src/message-mapper.ts
+++ b/src/message-mapper.ts
@@ -1,5 +1,5 @@
 import type { ModelMessage } from 'ai';
-import type { SharedV3Warning } from '@ai-sdk/provider';
+import type { SharedV4Warning } from '@ai-sdk/provider';
 import { convertPromptToCodexInput, type PromptMessage } from './converters/index.js';
 import type { ImageData } from './image-utils.js';
 
@@ -8,7 +8,7 @@ export type { ImageData };
 export function mapMessagesToPrompt(prompt: readonly ModelMessage[]): {
   promptText: string;
   images: ImageData[];
-  warnings?: SharedV3Warning[];
+  warnings?: SharedV4Warning[];
 } {
   const converted = convertPromptToCodexInput({
     prompt: prompt as unknown as readonly PromptMessage[],
@@ -16,7 +16,7 @@ export function mapMessagesToPrompt(prompt: readonly ModelMessage[]): {
     includeRemoteImagesInMarkers: false,
   });
 
-  const warnings: SharedV3Warning[] = converted.warnings.map((warning) =>
+  const warnings: SharedV4Warning[] = converted.warnings.map((warning) =>
     warning.type === 'unsupported'
       ? {
           type: 'unsupported',

--- a/src/shared-utils.ts
+++ b/src/shared-utils.ts
@@ -257,7 +257,14 @@ export function mapUnsupportedSettingsWarnings(options: {
   add(options.stopSequences?.length ? options.stopSequences : undefined, 'stopSequences');
   add(options.seed, 'seed');
   add(options.tools, 'tools');
-  add(options.toolChoice, 'toolChoice');
+  // ai@7 normalizes an unset toolChoice to { type: 'auto' } before calling the
+  // provider, so a bare 'auto' carries no user intent — warn only for
+  // meaningful choices ('required' | 'none' | 'tool').
+  const toolChoice = options.toolChoice as { type?: unknown } | undefined;
+  add(
+    toolChoice !== undefined && toolChoice.type === 'auto' ? undefined : toolChoice,
+    'toolChoice',
+  );
 
   return unsupported;
 }

--- a/src/shared-utils.ts
+++ b/src/shared-utils.ts
@@ -1,7 +1,7 @@
 import type {
-  LanguageModelV3FinishReason,
-  LanguageModelV3Usage,
-  SharedV3Warning,
+  LanguageModelV4FinishReason,
+  LanguageModelV4Usage,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import type {
   CodexConfigOverrideValue,
@@ -11,7 +11,7 @@ import type {
 } from './types-shared.js';
 import { assertValidConfigOverrideKey, assertValidMcpServerName } from './config-key-utils.js';
 
-export function createEmptyCodexUsage(): LanguageModelV3Usage {
+export function createEmptyCodexUsage(): LanguageModelV4Usage {
   return {
     inputTokens: {
       total: undefined,
@@ -28,7 +28,7 @@ export function createEmptyCodexUsage(): LanguageModelV3Usage {
   };
 }
 
-export function mapCodexCliFinishReason(reason?: string): LanguageModelV3FinishReason {
+export function mapCodexCliFinishReason(reason?: string): LanguageModelV4FinishReason {
   switch (reason) {
     case 'stop':
     case 'end_turn':
@@ -236,8 +236,8 @@ export function mapUnsupportedSettingsWarnings(options: {
   seed?: unknown;
   tools?: unknown;
   toolChoice?: unknown;
-}): SharedV3Warning[] {
-  const unsupported: SharedV3Warning[] = [];
+}): SharedV4Warning[] {
+  const unsupported: SharedV4Warning[] = [];
   const add = (setting: unknown, name: string) => {
     if (setting !== undefined) {
       unsupported.push({

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   sourcemap: false,
   clean: true,
   dts: true,
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   target: 'es2022',
   treeshake: true,
 });


### PR DESCRIPTION
## Summary
- Cut AI SDK v7 release line as 2.0.0 with native LanguageModelV4/ProviderV4 support.
- Switch package to ESM-only, Node >=22, @ai-sdk/provider ^4, @ai-sdk/provider-utils ^5, ai ^7 dev, zod peer ^3.25.76 || ^4.1.8.
- Harden converters for v4 tagged file data, canonical tool-result file content, top-level media types, custom/reasoning-file warnings, and top-level reasoning mapping.
- Sync app-server protocol types with Codex CLI 0.142.5 and bump optional @openai/codex to ^0.142.5.
- Add ai@7 integration coverage, update examples, README, changelog, and docs/ai-sdk-v7.
- Apply Opus review hardening: app-server reasoning guard, turn/completed drift tolerance, v7 README snippets, supportedUrls regression assertions, and Codex 0.142.5 source/example baseline alignment.
- Semantically validate all 60 examples with one gpt-5.5:xhigh agent per example; fixed the three examples whose output did not fully demonstrate their stated intent.

## Verification
- npm run validate
- npm run validate:docs
- ESM import smoke
- listModels() against /Users/ben/.local/bin/codex (0.142.5) returned gpt-5.5/gpt-5.4/gpt-5.4-mini/gpt-5.3-codex-spark
- Representative live examples: app-server basic-usage/raw-chunks, exec streaming
- npm run validate:examples:app-server (33/33 passed)
- One-agent-per-example semantic validation: 60/60 passed after fixes

## Release setup
- ai-sdk-v6 git branch pushed.
- npm dist-tag ai-sdk-v6 points to ai-sdk-provider-codex-cli@1.2.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major semver with breaking runtime (Node 22, ESM-only), provider contract (v4), and consumer API changes; incorrect converter or stream mapping would break production AI SDK integrations.
> 
> **Overview**
> **2.0.0** moves the package to **AI SDK v7** with native **`LanguageModelV4` / `ProviderV4`** (`specificationVersion: 'v4'`), dropping the v6 provider surface and legacy model flags (`defaultObjectGenerationMode`, `supportsStructuredOutputs`, `supportsImageUrls`). **Node ≥ 22** and **ESM-only** packaging (no CJS `require` export) are required; dependencies align to `@ai-sdk/provider` ^4, `@ai-sdk/provider-utils` ^5, optional **`@openai/codex` ^0.142.5**, and a tighter **zod** peer.
> 
> Provider behavior adds the AI SDK v7 top-level **`reasoning`** option (mapped to Codex effort with provider-specific override precedence), **v4 file/image** and **canonical tool-result file** handling, and explicit **unsupported** warnings for `custom` / `reasoning-file` parts. App-server work includes **`dynamicToolCall`** stream mapping, safer **raw-chunk + thread resume** warnings, and **developer instructions** on thread resume when system text is present.
> 
> **README**, **CHANGELOG**, new **`docs/ai-sdk-v7/*`**, and all **examples** adopt v7 APIs (`instructions`, `result.stream`, `include: { rawChunks: true }`, `finalStep.providerMetadata`, flat usage). New **`ai-sdk-v7-integration`** tests exercise real `ai@7` entrypoints; the **1.x** line is documented via the **`ai-sdk-v6`** npm tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75215879a99c775caafd9caaf26563bc19cb05cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->