### PR TITLE
feat: bump @openai/codex optional dependency to ^0.144.0 (1.x line)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-07-10
+
+### Changed
+
+- Update the optional `@openai/codex` dependency from `^0.130.0` to `^0.144.0`, making Codex CLI 0.144.x the validated support baseline for both `codexExec` and `codexAppServer` on the AI SDK v6 line (#36). The previous `^0.130.0` caret capped installs at 0.130.x, so the bundled CLI could silently shadow a newer global install via `node_modules/.bin`.
+- Raise the app-server default `minCodexVersion` from `0.130.0` to `0.144.0` to match the new baseline (set `minCodexVersion` explicitly to accept older CLIs).
+- Refresh AI SDK v6 lockfile dependencies for the new Codex baseline.
+
 ## [1.2.2] - 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm i ai ai-sdk-provider-codex-cli
 npm i ai@^5.0.0 ai-sdk-provider-codex-cli@ai-sdk-v5
 ```
 
-> **⚠️ Codex CLI Version**: Requires the current stable Codex CLI **0.130.x** for full support of both provider modes (`codexExec` and `codexAppServer`). This package pins its optional `@openai/codex` dependency to `^0.130.0`, the latest non-alpha release validated for this maintenance update. If you supply your own Codex CLI (global install or custom `codexPath`), check it with `codex --version` and upgrade if needed.
+> **⚠️ Codex CLI Version**: Requires the current stable Codex CLI **0.144.x** for full support of both provider modes (`codexExec` and `codexAppServer`). This package pins its optional `@openai/codex` dependency to `^0.144.0`, the latest non-alpha release line validated for this maintenance update. If you supply your own Codex CLI (global install or custom `codexPath`), check it with `codex --version` and upgrade if needed.
 >
 > ```bash
 > npm i -g @openai/codex@latest
@@ -90,7 +90,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.130.0',
+    minCodexVersion: '0.144.0',
     autoApprove: false,
     personality: 'pragmatic',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-codex-cli",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",
@@ -30,7 +30,7 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@openai/codex": "^0.130.0"
+        "@openai/codex": "^0.144.0"
       },
       "peerDependencies": {
         "zod": "^3.0.0 || ^4.0.0"
@@ -877,9 +877,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0.tgz",
-      "integrity": "sha512-WGDj+RZ3TXWC/7MlwprgLWOqzpwatPIINPhP3IRzHA0ni+o3QZ4i4xrS2uWwGmHUJ395J5JHwoZAAZYyfJyz6w==",
+      "version": "0.144.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1.tgz",
+      "integrity": "sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==",
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -889,19 +889,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.130.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.130.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.130.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.130.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.130.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.130.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.1-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.130.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-arm64.tgz",
-      "integrity": "sha512-R9pkGC7kwC8yQ8el5hvBlmugQlcsG/pHMEFgZluu03X9fD2TezGxdq3KqRDRCZuMYl07ILamVEoqknuJ0cq7MA==",
+      "version": "0.144.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
+      "integrity": "sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==",
       "cpu": [
         "arm64"
       ],
@@ -916,9 +916,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.130.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-darwin-x64.tgz",
-      "integrity": "sha512-gJ+7J8djevgtdra+NgDAiQQPW+O3KTsgGfE3E5dpDfww3zS5OCeV0V2dhxqnJdlOjOSDw99o0P2LqBv19mhpRw==",
+      "version": "0.144.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
+      "integrity": "sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==",
       "cpu": [
         "x64"
       ],
@@ -933,9 +933,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.130.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-arm64.tgz",
-      "integrity": "sha512-tFtH0V9/hEI3d9y7zP92BXI9FM4Z3+STNQaOR52Czv18TRtCFUp7CbIUYaToopuq6UBfnE1VKr8RLhwT5FcbmA==",
+      "version": "0.144.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
+      "integrity": "sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==",
       "cpu": [
         "arm64"
       ],
@@ -950,9 +950,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.130.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-linux-x64.tgz",
-      "integrity": "sha512-3VcNlez99xdnEf+kB1IOpWv9fICYV9PiGj4sLCO4TCcShLnyxe+YBGa3poknkvXLnMG0qiN9SMnYS2FGrMxQcA==",
+      "version": "0.144.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
+      "integrity": "sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==",
       "cpu": [
         "x64"
       ],
@@ -967,9 +967,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.130.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-arm64.tgz",
-      "integrity": "sha512-vdpmiNp57L/arZabltLXn8TyEtNa7W1meOEkr+3R6W/8ZyBt++wuqz1Orv134OT2grrcFJsIVCAIPiqUxCvBkA==",
+      "version": "0.144.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-arm64.tgz",
+      "integrity": "sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==",
       "cpu": [
         "arm64"
       ],
@@ -984,9 +984,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.130.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.130.0-win32-x64.tgz",
-      "integrity": "sha512-FzMznm7fr5/nbjZgOujZ9Y9AbdGm7ji1FOoWiY3U+srqauvZaTgn6o6aCheSL7kuymu7nTLOO/cAyWV6NuesqQ==",
+      "version": "0.144.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
+      "integrity": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "AI SDK v6 provider for OpenAI Codex CLI (use ChatGPT Plus/Pro subscription)",
   "keywords": [
     "ai-sdk",
@@ -67,7 +67,7 @@
     "jsonc-parser": "^3.3.1"
   },
   "optionalDependencies": {
-    "@openai/codex": "^0.130.0"
+    "@openai/codex": "^0.144.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",

--- a/src/__tests__/app-server-integration.smoke.test.ts
+++ b/src/__tests__/app-server-integration.smoke.test.ts
@@ -14,7 +14,7 @@ describeIntegration('app-server integration smoke', () => {
       const modelId = process.env.CODEX_APP_SERVER_INTEGRATION_MODEL ?? 'gpt-5.3-codex';
       const provider = createCodexAppServer({
         defaultSettings: {
-          minCodexVersion: '0.130.0',
+          minCodexVersion: '0.144.0',
           connectionTimeoutMs: 60_000,
           codexPath,
           approvalPolicy: 'never',

--- a/src/__tests__/app-server-rpc-client.test.ts
+++ b/src/__tests__/app-server-rpc-client.test.ts
@@ -77,7 +77,7 @@ function createMockProcess(
           `${JSON.stringify({
             id: message.id,
             result: {
-              userAgent: options.userAgent ?? 'codex-cli 0.130.0',
+              userAgent: options.userAgent ?? 'codex-cli 0.144.1',
               capabilities: options.initializeCapabilities ?? null,
             },
           })}\n`,

--- a/src/app-server/provider.ts
+++ b/src/app-server/provider.ts
@@ -44,7 +44,7 @@ export interface CodexAppServerProvider extends ProviderV3 {
  * @example
  * ```ts
  * const provider = createCodexAppServer({
- *   defaultSettings: { minCodexVersion: '0.130.0' },
+ *   defaultSettings: { minCodexVersion: '0.144.0' },
  * });
  *
  * try {

--- a/src/app-server/rpc/client.ts
+++ b/src/app-server/rpc/client.ts
@@ -307,7 +307,7 @@ export class AppServerRpcClient extends EventEmitter {
     if (this.serverCapabilities?.modelList === false) {
       throw new UnsupportedFeatureError({
         feature: 'model/list',
-        minCodexVersion: this.settings.minCodexVersion ?? '0.130.0',
+        minCodexVersion: this.settings.minCodexVersion ?? '0.144.0',
         serverVersion: this.serverVersion,
       });
     }
@@ -321,7 +321,7 @@ export class AppServerRpcClient extends EventEmitter {
       if (error instanceof JsonRpcRequestError && error.code === -32601) {
         throw new UnsupportedFeatureError({
           feature: 'model/list',
-          minCodexVersion: this.settings.minCodexVersion ?? '0.130.0',
+          minCodexVersion: this.settings.minCodexVersion ?? '0.144.0',
           serverVersion: this.serverVersion,
         });
       }
@@ -512,7 +512,7 @@ export class AppServerRpcClient extends EventEmitter {
       const message = String((error as Error)?.message ?? error);
       if (message.includes('ENOENT') || message.includes('unknown subcommand')) {
         throw new Error(
-          "codex app-server requires codex CLI >= 0.130.0. Run 'codex --version' to check.",
+          "codex app-server requires codex CLI >= 0.144.0. Run 'codex --version' to check.",
         );
       }
 
@@ -538,7 +538,7 @@ export class AppServerRpcClient extends EventEmitter {
     }
 
     this.serverVersion = detected;
-    const minVersion = this.settings.minCodexVersion ?? '0.130.0';
+    const minVersion = this.settings.minCodexVersion ?? '0.144.0';
     const compared = compareSemver(detected, minVersion);
     if (compared === undefined) {
       this.logger.warn(


### PR DESCRIPTION
Addresses #36 on the AI SDK v6 maintenance line (1.x). Note for merge: GitHub won't auto-close the issue since the base isn't the default branch — close #36 manually after merging.

## Problem

The optional `@openai/codex` pin `^0.130.0` caps installs at 0.130.x (caret on 0.x only allows patch drift), while the current Codex CLI is 0.144.x. Because `npm run` prepends `node_modules/.bin` to PATH, the stale bundled CLI silently shadows newer global installs — the same drift previously fixed by #28.

## Changes

- `@openai/codex` optional dependency: `^0.130.0` → `^0.144.0` (resolves to 0.144.1 today)
- App-server default `minCodexVersion`: `0.130.0` → `0.144.0`, matching the pin, as 1.2.0 did for the last bump (users can still set `minCodexVersion` explicitly to accept older CLIs)
- README version note + examples, provider docstring, CHANGELOG 1.3.0 entry, lockfile refresh
- Tests: RPC-client mock default userAgent updated to 0.144.1; smoke test floor updated
- Version → 1.3.0 (minor, mirroring the 1.2.0 precedent for baseline bumps)

## Validation

- Full `npm run validate` (build/typecheck/format/lint/347 tests) passes
- Live app-server smoke test (`CODEX_APP_SERVER_INTEGRATION=1`) against the bundled 0.144.1: initialize + turn + stateful follow-up ✅
- Exec-mode `generateText` against bundled 0.144.1 ✅ (matches the reporter's production verification of 0.144.0)