### PR TITLE
feat: bump @openai/codex optional dependency to ^0.144.0 (2.x line)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-07-10
+
+### Changed
+
+- Update the optional `@openai/codex` dependency from `^0.142.5` to `^0.144.0`, making Codex CLI 0.144.x the validated support baseline for both `codexExec` and `codexAppServer` (same drift class as #36 on the 1.x line: a caret on a 0.x version only allows patch-level updates, so the bundled CLI could silently shadow a newer global install via `node_modules/.bin`).
+- Raise the app-server default `minCodexVersion` from `0.142.5` to `0.144.0` to match the new baseline (set `minCodexVersion` explicitly to accept older CLIs).
+- Refresh example and docs baseline references, and the lockfile, for the new Codex baseline.
+
 ## [2.0.0] - 2026-07-06
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm i ai@^6 ai-sdk-provider-codex-cli@ai-sdk-v6
 npm i ai@^5.0.0 ai-sdk-provider-codex-cli@ai-sdk-v5
 ```
 
-> **⚠️ Codex CLI Version**: Requires the current stable Codex CLI **0.142.x** for full support of both provider modes (`codexExec` and `codexAppServer`). This package pins its optional `@openai/codex` dependency to `^0.142.5`, the latest non-alpha release validated for this release line. If you supply your own Codex CLI (global install or custom `codexPath`), check it with `codex --version` and upgrade if needed.
+> **⚠️ Codex CLI Version**: Requires the current stable Codex CLI **0.144.x** for full support of both provider modes (`codexExec` and `codexAppServer`). This package pins its optional `@openai/codex` dependency to `^0.144.0`, the latest non-alpha release line validated for this release line. If you supply your own Codex CLI (global install or custom `codexPath`), check it with `codex --version` and upgrade if needed.
 >
 > ```bash
 > npm i -g @openai/codex@latest
@@ -100,7 +100,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.142.5',
+    minCodexVersion: '0.144.0',
     autoApprove: false,
     personality: 'pragmatic',
   },

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ Provider-specific notes:
   - `npm i -g @openai/codex`
   - `codex login` (or set `OPENAI_API_KEY`)
 - Build this package before running examples: `npm run build`
-- App-server examples require Codex CLI `>= 0.142.5`.
+- App-server examples require Codex CLI `>= 0.144.0`.
 
 ## Run
 

--- a/examples/app-server/abort.mjs
+++ b/examples/app-server/abort.mjs
@@ -2,7 +2,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/advanced-settings.mjs
+++ b/examples/app-server/advanced-settings.mjs
@@ -2,7 +2,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/basic-usage.mjs
+++ b/examples/app-server/basic-usage.mjs
@@ -2,7 +2,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/check-cli.mjs
+++ b/examples/app-server/check-cli.mjs
@@ -41,7 +41,7 @@ console.log('  app-server command available');
 console.log('\n Running minimal app-server generation...');
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.142.5',
+    minCodexVersion: '0.144.0',
     idleTimeoutMs: 30000,
     approvalPolicy: 'on-failure',
     sandboxPolicy: { type: 'workspaceWrite' },

--- a/examples/app-server/cmdline-limit-test.mjs
+++ b/examples/app-server/cmdline-limit-test.mjs
@@ -29,7 +29,7 @@ async function main() {
 
   const codex = createCodexAppServer({
     defaultSettings: {
-      minCodexVersion: '0.142.5',
+      minCodexVersion: '0.144.0',
       idleTimeoutMs: 30000,
       cwd: process.cwd(),
       approvalPolicy: 'on-failure',

--- a/examples/app-server/conversation-history.mjs
+++ b/examples/app-server/conversation-history.mjs
@@ -10,7 +10,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/custom-config.mjs
+++ b/examples/app-server/custom-config.mjs
@@ -2,7 +2,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const defaultSettings = {
-  minCodexVersion: '0.142.5',
+  minCodexVersion: '0.144.0',
   idleTimeoutMs: 30000,
 };
 

--- a/examples/app-server/error-handling.mjs
+++ b/examples/app-server/error-handling.mjs
@@ -4,7 +4,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer, isAuthenticationError } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/experimental-json-events.mjs
+++ b/examples/app-server/experimental-json-events.mjs
@@ -15,7 +15,7 @@ import { generateText, streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 function getUsageTotals(usage) {

--- a/examples/app-server/generate-object-advanced.mjs
+++ b/examples/app-server/generate-object-advanced.mjs
@@ -12,7 +12,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/generate-object-basic.mjs
+++ b/examples/app-server/generate-object-basic.mjs
@@ -13,7 +13,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/generate-object-constraints.mjs
+++ b/examples/app-server/generate-object-constraints.mjs
@@ -11,7 +11,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/generate-object-native-schema.mjs
+++ b/examples/app-server/generate-object-native-schema.mjs
@@ -15,7 +15,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/generate-object-nested.mjs
+++ b/examples/app-server/generate-object-nested.mjs
@@ -12,7 +12,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 import { z } from 'zod';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/image-support.mjs
+++ b/examples/app-server/image-support.mjs
@@ -24,7 +24,7 @@ import { generateText, streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/limitations.mjs
+++ b/examples/app-server/limitations.mjs
@@ -4,7 +4,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/list-models.mjs
+++ b/examples/app-server/list-models.mjs
@@ -3,7 +3,7 @@
 import { listModels } from 'ai-sdk-provider-codex-cli';
 
 const { models, defaultModel } = await listModels({
-  minCodexVersion: '0.142.5',
+  minCodexVersion: '0.144.0',
 });
 
 console.log(`Found ${models.length} model(s).`);

--- a/examples/app-server/local-mcp-tool.mjs
+++ b/examples/app-server/local-mcp-tool.mjs
@@ -18,7 +18,7 @@ const mathServer = createSdkMcpServer({
 
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.142.5',
+    minCodexVersion: '0.144.0',
     idleTimeoutMs: 30000,
     mcpServers: {
       math: mathServer,

--- a/examples/app-server/logging-custom-logger.mjs
+++ b/examples/app-server/logging-custom-logger.mjs
@@ -20,7 +20,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/logging-default.mjs
+++ b/examples/app-server/logging-default.mjs
@@ -18,7 +18,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/logging-disabled.mjs
+++ b/examples/app-server/logging-disabled.mjs
@@ -27,7 +27,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/logging-verbose.mjs
+++ b/examples/app-server/logging-verbose.mjs
@@ -24,7 +24,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/long-prompt-test.mjs
+++ b/examples/app-server/long-prompt-test.mjs
@@ -85,7 +85,7 @@ async function main() {
 
   const codex = createCodexAppServer({
     defaultSettings: {
-      minCodexVersion: '0.142.5',
+      minCodexVersion: '0.144.0',
       idleTimeoutMs: 30000,
       cwd: process.cwd(),
       approvalPolicy: 'on-failure',

--- a/examples/app-server/long-running-tasks.mjs
+++ b/examples/app-server/long-running-tasks.mjs
@@ -8,7 +8,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/permissions-and-sandbox.mjs
+++ b/examples/app-server/permissions-and-sandbox.mjs
@@ -11,7 +11,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/provider-options.mjs
+++ b/examples/app-server/provider-options.mjs
@@ -2,7 +2,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/raw-chunks.mjs
+++ b/examples/app-server/raw-chunks.mjs
@@ -2,7 +2,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/session-injection.mjs
+++ b/examples/app-server/session-injection.mjs
@@ -5,7 +5,7 @@ import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const provider = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.142.5',
+    minCodexVersion: '0.144.0',
     idleTimeoutMs: 30000,
     threadMode: 'persistent',
     effort: 'medium',

--- a/examples/app-server/streaming-multiple-tools.mjs
+++ b/examples/app-server/streaming-multiple-tools.mjs
@@ -7,7 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const appServer = createCodexAppServer({
   defaultSettings: {
-    minCodexVersion: '0.142.5',
+    minCodexVersion: '0.144.0',
     idleTimeoutMs: 30000,
     cwd: __dirname,
   },

--- a/examples/app-server/streaming-tool-calls.mjs
+++ b/examples/app-server/streaming-tool-calls.mjs
@@ -2,7 +2,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/streaming.mjs
+++ b/examples/app-server/streaming.mjs
@@ -2,7 +2,7 @@ import { streamText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/system-messages.mjs
+++ b/examples/app-server/system-messages.mjs
@@ -4,7 +4,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/examples/app-server/usage-metadata.mjs
+++ b/examples/app-server/usage-metadata.mjs
@@ -2,7 +2,7 @@ import { generateText } from 'ai';
 import { createCodexAppServer } from 'ai-sdk-provider-codex-cli';
 
 const appServer = createCodexAppServer({
-  defaultSettings: { minCodexVersion: '0.142.5', idleTimeoutMs: 30000 },
+  defaultSettings: { minCodexVersion: '0.144.0', idleTimeoutMs: 30000 },
 });
 
 try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-codex-cli",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.0",
@@ -30,10 +30,10 @@
         "node": ">=22"
       },
       "optionalDependencies": {
-        "@openai/codex": "^0.142.5"
+        "@openai/codex": "^0.144.0"
       },
       "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
+        "zod": "^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -878,9 +878,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.142.5",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5.tgz",
-      "integrity": "sha512-WQEpD7l3k68eIAP0aq28EdR18ENBAf8DyprzFhzNwCOQJSv4nHzpwT8Fl30IJacprko2ZCmUBZjM2u941l2yLw==",
+      "version": "0.144.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1.tgz",
+      "integrity": "sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==",
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -890,19 +890,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.5-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.5-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.5-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.142.5-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.5-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.142.5-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.1-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.142.5-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-darwin-arm64.tgz",
-      "integrity": "sha512-l43p8xv+Z/2/b6fCUc7/FmcQZsaPB7RFizLponGwHAnFOWe3i9Vky69p+up3BUam9AetoQQUv7Mo+2KdaFEqhA==",
+      "version": "0.144.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
+      "integrity": "sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==",
       "cpu": [
         "arm64"
       ],
@@ -917,9 +917,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.142.5-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-darwin-x64.tgz",
-      "integrity": "sha512-yk6A06/VmW7NFsa48OVPaj//g/zeSpd79wjuqfXZwW8ZKRYQm3+wCd3hWjPl79F3QnXvDvM2j3JMIBL3m3GXXg==",
+      "version": "0.144.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
+      "integrity": "sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==",
       "cpu": [
         "x64"
       ],
@@ -934,9 +934,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.142.5-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-linux-arm64.tgz",
-      "integrity": "sha512-77ka5PSnm5HdxdBT99IwntCasmbqevlS0eiC0AtEb6ZXCLkim2gm0AWm+jNYy0EhbssvNK+KghayWo34HMgXeA==",
+      "version": "0.144.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
+      "integrity": "sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==",
       "cpu": [
         "arm64"
       ],
@@ -951,9 +951,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.142.5-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-linux-x64.tgz",
-      "integrity": "sha512-pxY+d3NgNE57Y/MApD3/TZUAygxJN6I9h3ZeDUwe67mxWjUxsuapxMRFTKSznCalYbRAeZp752+AAXmUbmguEg==",
+      "version": "0.144.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
+      "integrity": "sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==",
       "cpu": [
         "x64"
       ],
@@ -968,9 +968,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.142.5-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-win32-arm64.tgz",
-      "integrity": "sha512-65BEqGbUZ7r0ayunIHdBjo5crwgbwKX/6puOcO+VCswUw/dXvDsN2IGcbXB52+bS9U5+FxP783cUHfTT6m40DQ==",
+      "version": "0.144.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-arm64.tgz",
+      "integrity": "sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==",
       "cpu": [
         "arm64"
       ],
@@ -985,9 +985,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.142.5-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.5-win32-x64.tgz",
-      "integrity": "sha512-a+wI4PEx9a2fg6V5ueTTDkOkr1XpEvA5RFXIbo/L2hOfzMmGtyRnbG24bCGu5Q2RSgVxSQV0aLkdb3vdYMNH9A==",
+      "version": "0.144.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
+      "integrity": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "AI SDK v7 provider for OpenAI Codex CLI (use ChatGPT Plus/Pro subscription)",
   "keywords": [
     "ai-sdk",
@@ -61,7 +61,7 @@
     "jsonc-parser": "^3.3.1"
   },
   "optionalDependencies": {
-    "@openai/codex": "^0.142.5"
+    "@openai/codex": "^0.144.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",

--- a/src/__tests__/app-server-integration.smoke.test.ts
+++ b/src/__tests__/app-server-integration.smoke.test.ts
@@ -14,7 +14,7 @@ describeIntegration('app-server integration smoke', () => {
       const modelId = process.env.CODEX_APP_SERVER_INTEGRATION_MODEL ?? 'gpt-5.3-codex';
       const provider = createCodexAppServer({
         defaultSettings: {
-          minCodexVersion: '0.142.5',
+          minCodexVersion: '0.144.0',
           connectionTimeoutMs: 60_000,
           codexPath,
           approvalPolicy: 'never',

--- a/src/__tests__/app-server-rpc-client.test.ts
+++ b/src/__tests__/app-server-rpc-client.test.ts
@@ -77,7 +77,7 @@ function createMockProcess(
           `${JSON.stringify({
             id: message.id,
             result: {
-              userAgent: options.userAgent ?? 'codex-cli 0.142.5',
+              userAgent: options.userAgent ?? 'codex-cli 0.144.1',
               capabilities: options.initializeCapabilities ?? null,
             },
           })}\n`,

--- a/src/app-server/provider.ts
+++ b/src/app-server/provider.ts
@@ -44,7 +44,7 @@ export interface CodexAppServerProvider extends ProviderV4 {
  * @example
  * ```ts
  * const provider = createCodexAppServer({
- *   defaultSettings: { minCodexVersion: '0.142.5' },
+ *   defaultSettings: { minCodexVersion: '0.144.0' },
  * });
  *
  * try {

--- a/src/app-server/rpc/client.ts
+++ b/src/app-server/rpc/client.ts
@@ -307,7 +307,7 @@ export class AppServerRpcClient extends EventEmitter {
     if (this.serverCapabilities?.modelList === false) {
       throw new UnsupportedFeatureError({
         feature: 'model/list',
-        minCodexVersion: this.settings.minCodexVersion ?? '0.142.5',
+        minCodexVersion: this.settings.minCodexVersion ?? '0.144.0',
         serverVersion: this.serverVersion,
       });
     }
@@ -321,7 +321,7 @@ export class AppServerRpcClient extends EventEmitter {
       if (error instanceof JsonRpcRequestError && error.code === -32601) {
         throw new UnsupportedFeatureError({
           feature: 'model/list',
-          minCodexVersion: this.settings.minCodexVersion ?? '0.142.5',
+          minCodexVersion: this.settings.minCodexVersion ?? '0.144.0',
           serverVersion: this.serverVersion,
         });
       }
@@ -512,7 +512,7 @@ export class AppServerRpcClient extends EventEmitter {
       const message = String((error as Error)?.message ?? error);
       if (message.includes('ENOENT') || message.includes('unknown subcommand')) {
         throw new Error(
-          "codex app-server requires codex CLI >= 0.142.5. Run 'codex --version' to check.",
+          "codex app-server requires codex CLI >= 0.144.0. Run 'codex --version' to check.",
         );
       }
 
@@ -538,7 +538,7 @@ export class AppServerRpcClient extends EventEmitter {
     }
 
     this.serverVersion = detected;
-    const minVersion = this.settings.minCodexVersion ?? '0.142.5';
+    const minVersion = this.settings.minCodexVersion ?? '0.144.0';
     const compared = compareSemver(detected, minVersion);
     if (compared === undefined) {
       this.logger.warn(


### PR DESCRIPTION
Applies the same fix pattern as #37 (issue #36) to the 2.x/latest line: `^0.142.5` caps installs at 0.142.x while the current Codex CLI is 0.144.1, so the bundled CLI can silently shadow a newer global install via `node_modules/.bin`.

## Changes

- `@openai/codex` optional dependency: `^0.142.5` → `^0.144.0` (resolves to 0.144.1 today)
- App-server default `minCodexVersion`: `0.142.5` → `0.144.0`, matching the pin (users can still set `minCodexVersion` explicitly to accept older CLIs)
- README version note + example, provider docstring, examples/README, 33 example files' explicit `minCodexVersion` baselines, CHANGELOG 2.1.0 entry, lockfile refresh
- Tests: RPC-client mock default userAgent → 0.144.1; smoke-test floor → 0.144.0
- Version → 2.1.0 (minor, per the baseline-bump precedent from 1.2.0/#28)

Protocol note: the vendored app-server protocol types (synced from 0.142.5) are unchanged — the 0.142-era wire contracts they describe are still what 0.144.1 speaks, verified by the protocol-compat suite plus live smoke below.

## Validation

- Full `npm run validate` (build/typecheck/format/lint/410 tests) + docs validation passes
- Live app-server smoke test against the bundled 0.144.1: initialize + turn + stateful follow-up ✅
- Exec-mode `generateText` against bundled 0.144.1 ✅