### PR TITLE
fix: surface captured stderr in app-server crash error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-07-10
+
+### Fixed
+
+- Surface a trimmed tail of captured stderr in app-server crash and initialization-failure messages (#39), making the root cause visible without inspecting `error.data.stderr`; report startup ENOENT failures with an installation-integrity hint instead of the misleading minimum-version hint; and apply the version hint when `unknown subcommand` appears only in stderr.
+
 ## [2.1.0] - 2026-07-10
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-codex-cli",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "AI SDK v7 provider for OpenAI Codex CLI (use ChatGPT Plus/Pro subscription)",
   "keywords": [
     "ai-sdk",

--- a/src/__tests__/app-server-rpc-client.test.ts
+++ b/src/__tests__/app-server-rpc-client.test.ts
@@ -56,6 +56,7 @@ function createMockProcess(
   options: {
     userAgent?: string;
     disableModelList?: boolean;
+    disableInitialize?: boolean;
     initializeCapabilities?: Record<string, unknown> | null;
   } = {},
 ): MockProcess {
@@ -73,6 +74,7 @@ function createMockProcess(
       writes.push(message);
 
       if (message.method === 'initialize') {
+        if (options.disableInitialize) continue;
         child.stdout.write(
           `${JSON.stringify({
             id: message.id,
@@ -1016,6 +1018,7 @@ describe('AppServerRpcClient', () => {
 
     await client.ensureReady();
     first.child.emit('exit', 1, null);
+    first.child.emit('close', 1, null);
     await client.ensureReady();
 
     expect(spawns).toBe(2);
@@ -1052,9 +1055,238 @@ describe('AppServerRpcClient', () => {
     await client.ensureReady();
 
     child.emit('exit', 1, null);
+    child.emit('close', 1, null);
     await flush();
 
     expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    await client.close();
+  });
+
+  it('includes captured stderr in pending request crash rejections', async () => {
+    const { child } = createMockProcess();
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient();
+    await client.ensureReady();
+
+    const failure = client.request('never/reply', {}).then(
+      () => new Error('Expected request to reject'),
+      (error: unknown) => error,
+    );
+    await flush();
+    child.stderr.write('fatal crash detail\n');
+    child.emit('exit', 1, null);
+    child.emit('close', 1, null);
+
+    const error = await failure;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('stderr (tail): fatal crash detail');
+    await client.close();
+  });
+
+  it('includes captured stderr once in initialization crash APICallErrors', async () => {
+    const { child } = createMockProcess({ disableInitialize: true });
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient();
+    const failure = client.ensureReady().then(
+      () => new Error('Expected initialization to reject'),
+      (error: unknown) => error,
+    );
+    await flush();
+
+    const rawStderr = 'initialization crashed with a detailed cause\n';
+    child.stderr.write(rawStderr);
+    child.emit('exit', 1, null);
+    child.emit('close', 1, null);
+
+    const error = await failure;
+    expect(error).toMatchObject({
+      name: 'AI_APICallError',
+      data: { stderr: rawStderr },
+    });
+    expect((error as Error).message).toContain(
+      'stderr (tail): initialization crashed with a detailed cause',
+    );
+    expect((error as Error).message.match(/stderr \(tail\):/g)).toHaveLength(1);
+    await client.close();
+  });
+
+  it('does not append a stderr suffix when an unexpected exit captured no stderr', async () => {
+    const { child } = createMockProcess();
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient();
+    await client.ensureReady();
+
+    const failure = client.request('never/reply', {}).then(
+      () => new Error('Expected request to reject'),
+      (error: unknown) => error,
+    );
+    await flush();
+    child.emit('exit', 1, null);
+    child.emit('close', 1, null);
+
+    const error = await failure;
+    expect((error as Error).message).not.toContain('stderr (tail)');
+    await client.close();
+  });
+
+  it('uses an installation-integrity hint for ENOENT captured during initialization', async () => {
+    const { child } = createMockProcess({ disableInitialize: true });
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient();
+    const failure = client.ensureReady().then(
+      () => new Error('Expected initialization to reject'),
+      (error: unknown) => error,
+    );
+    await flush();
+
+    child.stderr.write('spawn /x/y/codex ENOENT\n');
+    child.emit('exit', 1, null);
+    child.emit('close', 1, null);
+
+    const error = await failure;
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toMatchObject({ name: 'AI_APICallError' });
+    expect((error as Error).message).toContain(
+      'codex app-server failed to start: codex executable not found (ENOENT)',
+    );
+    expect((error as Error).message).toContain('stderr (tail): spawn /x/y/codex ENOENT');
+    expect((error as Error).message).not.toContain('requires codex CLI >=');
+    await client.close();
+  });
+
+  it('prioritizes an unknown-subcommand version hint found only in stderr', async () => {
+    const { child } = createMockProcess({ disableInitialize: true });
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient();
+    const failure = client.ensureReady().then(
+      () => new Error('Expected initialization to reject'),
+      (error: unknown) => error,
+    );
+    await flush();
+
+    child.stderr.write("spawn /x/y/codex ENOENT\nerror: unknown subcommand 'app-server'\n");
+    child.emit('exit', 1, null);
+    child.emit('close', 1, null);
+
+    const error = await failure;
+    expect((error as Error).message).toContain('codex app-server requires codex CLI >= 0.144.0');
+    expect((error as Error).message).toContain("error: unknown subcommand 'app-server'");
+    expect((error as Error).message).not.toContain('codex executable not found');
+    await client.close();
+  });
+
+  it('adds stderr exactly once when initialization times out without a process crash', async () => {
+    const { child } = createMockProcess({ disableInitialize: true });
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient({
+      settings: { connectionTimeoutMs: 10 },
+    });
+    const failure = client.ensureReady().then(
+      () => new Error('Expected initialization to reject'),
+      (error: unknown) => error,
+    );
+    const rawStderr = 'server remained alive but initialization stalled\n';
+    child.stderr.write(rawStderr);
+
+    const error = await failure;
+    expect(error).toMatchObject({
+      name: 'AI_APICallError',
+      data: { stderr: rawStderr },
+    });
+    expect((error as Error).message).toContain(
+      'stderr (tail): server remained alive but initialization stalled',
+    );
+    expect((error as Error).message.match(/stderr \(tail\):/g)).toHaveLength(1);
+    await client.close();
+  });
+
+  it('renders a single-line, last-five-line, tail-truncated stderr excerpt', async () => {
+    const { child } = createMockProcess();
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient();
+    await client.ensureReady();
+
+    const failure = client.request('never/reply', {}).then(
+      () => new Error('Expected request to reject'),
+      (error: unknown) => error,
+    );
+    await flush();
+    child.stderr.write(
+      [
+        'discard-one',
+        'discard-two',
+        'keep-one',
+        'keep-two',
+        'keep-three',
+        'keep-four',
+        `${'x'.repeat(620)}tail-end`,
+      ].join('\n'),
+    );
+    child.emit('exit', 1, null);
+    child.emit('close', 1, null);
+
+    const error = await failure;
+    const excerpt = (error as Error).message.split('stderr (tail): ')[1];
+    expect(excerpt).toBeDefined();
+    expect(excerpt).not.toContain('\n');
+    expect(excerpt).not.toContain('discard-one');
+    expect(excerpt).not.toContain('discard-two');
+    expect(excerpt).toMatch(/^…/);
+    expect(excerpt).toHaveLength(601);
+    expect(excerpt).toMatch(/tail-end$/);
+    await client.close();
+  });
+
+  it('captures stderr delivered after exit but before close', async () => {
+    const { child } = createMockProcess();
+    setSpawnMock(() => child);
+
+    const client = new AppServerRpcClient();
+    await client.ensureReady();
+
+    const failure = client.request('never/reply', {}).then(
+      () => new Error('Expected request to reject'),
+      (error: unknown) => error,
+    );
+    await flush();
+    child.emit('exit', 1, null);
+    child.stderr.write('late stderr chunk from drain race\n');
+    child.emit('close', 1, null);
+
+    const error = await failure;
+    expect((error as Error).message).toContain('stderr (tail): late stderr chunk from drain race');
+    await client.close();
+  });
+
+  it('logs unexpected exits with stderr as one exact single-line warning', async () => {
+    const { child } = createMockProcess();
+    setSpawnMock(() => child);
+
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const client = new AppServerRpcClient({ settings: { logger } });
+    await client.ensureReady();
+
+    child.stderr.write('first stderr line\nsecond stderr line\n');
+    child.emit('exit', 7, null);
+    child.emit('close', 7, null);
+    await flush();
+
+    const expectedWarning =
+      '[codex-app-server] codex app-server exited (code=7, signal=null) | stderr (tail): first stderr line; second stderr line';
+    expect(logger.warn).toHaveBeenCalledWith(expectedWarning);
+    expect(expectedWarning).not.toContain('\n');
     await client.close();
   });
 
@@ -1109,6 +1341,7 @@ describe('AppServerRpcClient', () => {
     ).toBe(1);
 
     child.emit('exit', 1, null);
+    child.emit('close', 1, null);
     await flush();
 
     expect(

--- a/src/__tests__/app-server-rpc-client.test.ts
+++ b/src/__tests__/app-server-rpc-client.test.ts
@@ -1033,6 +1033,88 @@ describe('AppServerRpcClient', () => {
     await client.close();
   });
 
+  it('respawns immediately while the previous child is still draining stderr', async () => {
+    const first = createMockProcess();
+    const second = createMockProcess();
+    let spawns = 0;
+    setSpawnMock(() => {
+      spawns += 1;
+      return spawns === 1 ? first.child : second.child;
+    });
+
+    const client = new AppServerRpcClient();
+    await client.ensureReady();
+
+    first.child.emit('exit', 1, null);
+    const reconnected = client.ensureReady();
+
+    expect(spawns).toBe(2);
+    await expect(reconnected).resolves.toBeUndefined();
+
+    const beforeClose = await client.threadStart({
+      experimentalRawEvents: false,
+      persistExtendedHistory: false,
+    });
+    expect(beforeClose.thread.id).toBe('thr_1');
+
+    first.child.emit('close', 1, null);
+    await flush();
+
+    const afterClose = await client.threadStart({
+      experimentalRawEvents: false,
+      persistExtendedHistory: false,
+    });
+    expect(afterClose.thread.id).toBe('thr_1');
+    expect(spawns).toBe(2);
+
+    await client.close();
+  });
+
+  it('rejects old pending requests with late stderr without polluting a respawn', async () => {
+    const first = createMockProcess();
+    const second = createMockProcess({ disableInitialize: true });
+    let spawns = 0;
+    setSpawnMock(() => {
+      spawns += 1;
+      return spawns === 1 ? first.child : second.child;
+    });
+
+    const client = new AppServerRpcClient();
+    await client.ensureReady();
+
+    const oldFailure = client.request('never/reply', {}).then(
+      () => new Error('Expected old request to reject'),
+      (error: unknown) => error,
+    );
+    await flush();
+
+    first.child.emit('exit', 1, null);
+    first.child.stderr.write('late stderr from old child\n');
+
+    const respawnFailure = client.ensureReady().then(
+      () => new Error('Expected respawn initialization to reject'),
+      (error: unknown) => error,
+    );
+    expect(spawns).toBe(2);
+
+    first.child.emit('close', 1, null);
+    const oldError = await oldFailure;
+    expect(oldError).toBeInstanceOf(Error);
+    expect((oldError as Error).message).toContain('stderr (tail): late stderr from old child');
+
+    second.child.emit('exit', 2, null);
+    second.child.emit('close', 2, null);
+
+    const respawnError = await respawnFailure;
+    expect(respawnError).toMatchObject({
+      name: 'AI_APICallError',
+      data: { stderr: '' },
+    });
+    expect((respawnError as Error).message).not.toContain('late stderr from old child');
+
+    await client.close();
+  });
+
   it('kills the child process on process error before entering error state', async () => {
     const { child } = createMockProcess();
     setSpawnMock(() => child);

--- a/src/app-server/rpc/client.ts
+++ b/src/app-server/rpc/client.ts
@@ -186,6 +186,7 @@ export class AppServerRpcClient extends EventEmitter {
   private activeRequestContextsByTurn = new Map<string, ActiveRequestContext>();
   private completedTurnIds = new Set<string>();
   private lastStderr = '';
+  private lastCrashHadStderr = false;
   private idleTimer?: NodeJS.Timeout;
   private serverCapabilities?: Record<string, unknown> | null;
   private expectedExitSignal?: NodeJS.Signals;
@@ -445,6 +446,7 @@ export class AppServerRpcClient extends EventEmitter {
     const args = [...base.args, 'app-server', '--listen', 'stdio://'];
 
     this.lastStderr = '';
+    this.lastCrashHadStderr = false;
     this.expectedExitSignal = undefined;
     this.child = spawn(base.cmd, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -456,20 +458,25 @@ export class AppServerRpcClient extends EventEmitter {
       cwd: this.settings.cwd,
     });
 
-    this.child.stderr.setEncoding('utf8');
-    this.child.stderr.on('data', (chunk) => {
+    const child = this.child;
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => {
+      if (this.child !== child) return;
       this.lastStderr += String(chunk);
       if (this.lastStderr.length > 4000) {
         this.lastStderr = this.lastStderr.slice(-4000);
       }
     });
 
-    this.child.on('error', (error) => {
+    child.on('error', (error) => {
       this.logger.error(`[codex-app-server] process error: ${String(error)}`);
-      this.handleCrash(error);
+      const base = String(error);
+      const message = this.withStderrTail(base);
+      this.lastCrashHadStderr = message !== base;
+      this.handleCrash(new Error(message));
     });
 
-    this.child.on('exit', (code, signal) => {
+    child.on('exit', (code, signal) => {
       const message = `codex app-server exited (code=${String(code)}, signal=${String(signal)})`;
       const expected =
         this.state === 'closed' || (signal !== null && signal === this.expectedExitSignal);
@@ -479,12 +486,30 @@ export class AppServerRpcClient extends EventEmitter {
         return;
       }
 
-      this.logger.warn(`[codex-app-server] ${message}`);
-      this.handleCrash(new Error(message));
+      let settled = false;
+      const finish = (): void => {
+        if (settled) return;
+        settled = true;
+        child.off('close', finish);
+        clearTimeout(timer);
+        if (this.state === 'closed' || this.state === 'error' || this.child !== child) {
+          return;
+        }
+
+        const base = `codex app-server exited (code=${String(code)}, signal=${String(signal)})`;
+        const crashMessage = this.withStderrTail(base);
+        this.lastCrashHadStderr = crashMessage !== base;
+        this.logger.warn(`[codex-app-server] ${crashMessage}`);
+        this.handleCrash(new Error(crashMessage));
+      };
+
+      child.once('close', finish);
+      const timer = setTimeout(finish, 120);
+      timer.unref?.();
     });
 
     this.stdoutReader = readline.createInterface({
-      input: this.child.stdout,
+      input: child.stdout,
       crlfDelay: Infinity,
     });
 
@@ -509,13 +534,23 @@ export class AppServerRpcClient extends EventEmitter {
         this.settings.connectionTimeoutMs ?? this.requestTimeoutMs,
       );
     } catch (error) {
-      const message = String((error as Error)?.message ?? error);
-      if (message.includes('ENOENT') || message.includes('unknown subcommand')) {
+      const raw = String((error as Error)?.message ?? error);
+      if (raw.includes('unknown subcommand') || this.lastStderr.includes('unknown subcommand')) {
         throw new Error(
-          "codex app-server requires codex CLI >= 0.144.0. Run 'codex --version' to check.",
+          this.withStderrTail(
+            "codex app-server requires codex CLI >= 0.144.0. Run 'codex --version' to check.",
+          ),
+        );
+      }
+      if (raw.includes('ENOENT') || this.lastStderr.includes('ENOENT')) {
+        throw new Error(
+          this.withStderrTail(
+            "codex app-server failed to start: codex executable not found (ENOENT). Check that the codex CLI is installed and its native binary is intact — a corrupted @openai/codex npm install can cause this. Run 'codex --version' to verify.",
+          ),
         );
       }
 
+      const message = this.lastCrashHadStderr ? raw : this.withStderrTail(raw);
       throw createAPICallError({
         message: `Failed to initialize codex app-server: ${message}`,
         stderr: this.lastStderr,
@@ -587,7 +622,7 @@ export class AppServerRpcClient extends EventEmitter {
   }
 
   private handleCrash(error: unknown): void {
-    if (this.state === 'closed') return;
+    if (this.state === 'closed' || this.state === 'error') return;
 
     this.state = 'error';
     this.clearIdleTimer();
@@ -613,6 +648,39 @@ export class AppServerRpcClient extends EventEmitter {
     this.completedTurnIds.clear();
     this.serverCapabilities = undefined;
     this.writeQueue = Promise.resolve();
+  }
+
+  private stderrExcerpt(): string {
+    if (!this.lastStderr) return '';
+
+    const escape = String.fromCharCode(27);
+    const ansiEscapeSequence = new RegExp(
+      `${escape}(?:\\[[0-?]*[ -/]*[@-~]|\\][^\\u0007]*(?:\\u0007|${escape}\\\\))`,
+      'g',
+    );
+    const withoutAnsi = this.lastStderr.replace(ansiEscapeSequence, '');
+    const withoutControls = Array.from(withoutAnsi)
+      .filter((character) => {
+        const code = character.charCodeAt(0);
+        return character === '\n' || (code >= 32 && (code < 127 || code > 159));
+      })
+      .join('');
+    const excerpt = withoutControls
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .slice(-5)
+      .join('; ');
+
+    if (excerpt.length > 600) {
+      return `…${excerpt.slice(-600)}`;
+    }
+    return excerpt;
+  }
+
+  private withStderrTail(message: string): string {
+    const excerpt = this.stderrExcerpt();
+    return excerpt ? `${message} | stderr (tail): ${excerpt}` : message;
   }
 
   private handleLine(line: string): void {

--- a/src/app-server/rpc/client.ts
+++ b/src/app-server/rpc/client.ts
@@ -459,19 +459,19 @@ export class AppServerRpcClient extends EventEmitter {
     });
 
     const child = this.child;
+    let stderrBuf = '';
     child.stderr.setEncoding('utf8');
     child.stderr.on('data', (chunk) => {
-      if (this.child !== child) return;
-      this.lastStderr += String(chunk);
-      if (this.lastStderr.length > 4000) {
-        this.lastStderr = this.lastStderr.slice(-4000);
+      stderrBuf = (stderrBuf + String(chunk)).slice(-4000);
+      if (this.child === child) {
+        this.lastStderr = stderrBuf;
       }
     });
 
     child.on('error', (error) => {
       this.logger.error(`[codex-app-server] process error: ${String(error)}`);
       const base = String(error);
-      const message = this.withStderrTail(base);
+      const message = this.withStderrTail(base, stderrBuf);
       this.lastCrashHadStderr = message !== base;
       this.handleCrash(new Error(message));
     });
@@ -486,21 +486,29 @@ export class AppServerRpcClient extends EventEmitter {
         return;
       }
 
+      const crashedPending = this.markCrashed();
+      if (!crashedPending) return;
+
       let settled = false;
       const finish = (): void => {
         if (settled) return;
         settled = true;
         child.off('close', finish);
         clearTimeout(timer);
-        if (this.state === 'closed' || this.state === 'error' || this.child !== child) {
-          return;
-        }
 
         const base = `codex app-server exited (code=${String(code)}, signal=${String(signal)})`;
-        const crashMessage = this.withStderrTail(base);
-        this.lastCrashHadStderr = crashMessage !== base;
+        const crashMessage = this.withStderrTail(base, stderrBuf);
+
+        if (this.child === undefined) {
+          // No respawn has started yet for this instance; keep instance-level stderr
+          // state consistent (including any late chunks captured in stderrBuf) so a
+          // subsequent initialize-catch classification/message sees the same data.
+          this.lastStderr = stderrBuf;
+          this.lastCrashHadStderr = crashMessage !== base;
+        }
+
         this.logger.warn(`[codex-app-server] ${crashMessage}`);
-        this.handleCrash(new Error(crashMessage));
+        this.rejectCrashedPending(crashedPending, new Error(crashMessage));
       };
 
       child.once('close', finish);
@@ -621,8 +629,8 @@ export class AppServerRpcClient extends EventEmitter {
     this.writeQueue = Promise.resolve();
   }
 
-  private handleCrash(error: unknown): void {
-    if (this.state === 'closed' || this.state === 'error') return;
+  private markCrashed(): Map<JsonRpcId, PendingRequest> | undefined {
+    if (this.state === 'closed' || this.state === 'error') return undefined;
 
     this.state = 'error';
     this.clearIdleTimer();
@@ -634,13 +642,12 @@ export class AppServerRpcClient extends EventEmitter {
       this.child = undefined;
     }
 
-    for (const [id, pending] of this.pending.entries()) {
-      clearTimeout(pending.timer);
-      pending.reject(
-        new Error(`Request ${String(id)} failed after app-server crash: ${String(error)}`),
-      );
+    const pending = new Map(this.pending);
+    for (const [, entry] of pending) {
+      clearTimeout(entry.timer);
     }
     this.pending.clear();
+
     this.threadLocks.clear();
     this.pendingRequestContexts.clear();
     this.pendingRequestContextIdsByThread.clear();
@@ -648,17 +655,33 @@ export class AppServerRpcClient extends EventEmitter {
     this.completedTurnIds.clear();
     this.serverCapabilities = undefined;
     this.writeQueue = Promise.resolve();
+
+    return pending;
   }
 
-  private stderrExcerpt(): string {
-    if (!this.lastStderr) return '';
+  private rejectCrashedPending(pending: Map<JsonRpcId, PendingRequest>, error: unknown): void {
+    for (const [id, entry] of pending) {
+      entry.reject(
+        new Error(`Request ${String(id)} failed after app-server crash: ${String(error)}`),
+      );
+    }
+  }
+
+  private handleCrash(error: unknown): void {
+    const pending = this.markCrashed();
+    if (!pending) return;
+    this.rejectCrashedPending(pending, error);
+  }
+
+  private stderrExcerpt(raw: string): string {
+    if (!raw) return '';
 
     const escape = String.fromCharCode(27);
     const ansiEscapeSequence = new RegExp(
       `${escape}(?:\\[[0-?]*[ -/]*[@-~]|\\][^\\u0007]*(?:\\u0007|${escape}\\\\))`,
       'g',
     );
-    const withoutAnsi = this.lastStderr.replace(ansiEscapeSequence, '');
+    const withoutAnsi = raw.replace(ansiEscapeSequence, '');
     const withoutControls = Array.from(withoutAnsi)
       .filter((character) => {
         const code = character.charCodeAt(0);
@@ -678,8 +701,8 @@ export class AppServerRpcClient extends EventEmitter {
     return excerpt;
   }
 
-  private withStderrTail(message: string): string {
-    const excerpt = this.stderrExcerpt();
+  private withStderrTail(message: string, raw: string = this.lastStderr): string {
+    const excerpt = this.stderrExcerpt(raw);
     return excerpt ? `${message} | stderr (tail): ${excerpt}` : message;
   }
 


### PR DESCRIPTION
## Summary

Fixes #39 on the 2.x (AI SDK v7) line. When the `codex app-server` child process dies before responding, the consumer-visible error was a generic `codex app-server exited (code=1, signal=null)` while the actual cause (e.g. `spawn .../codex ENOENT` from a corrupted `@openai/codex` install) was only available in `error.data.stderr`, which nothing surfaces by default.

## Changes

- **stderr tail in messages**: crash and initialization-failure error messages now append ` | stderr (tail): …` — a single-line excerpt (ANSI/control-stripped, last 5 non-empty lines, 600-char tail cap). Pending-request rejections, the initialize wrapper, and the `APICallError` inherit it. `error.data.stderr` still carries the full raw capture.
- **Classification separated from presentation** (per the interaction flagged in the issue): the initialize catch now classifies from the raw rejection message *and* raw captured stderr, so the enriched display message can't distort hint selection:
  - `unknown subcommand` (message **or stderr** — issue suggestion 2) → the existing `requires codex CLI >= 0.144.0` hint, now with the stderr tail.
  - `ENOENT` → a new installation-integrity hint ("codex executable not found … a corrupted @openai/codex npm install can cause this") instead of the previously misleading minimum-version hint, with the stderr tail.
- **Drain grace window**: unexpected-exit crash handling now waits for the child `close` event (120 ms cap) before building the message, so stderr chunks delivered after `exit` aren't lost. Expected-exit (SIGTERM shutdown) behavior is unchanged.
- **Hardening**: the stderr listener ignores chunks from a stale child after respawn; `handleCrash` is idempotent when a crash double-fires (`error` + deferred `exit`).
- **Release**: 2.1.0 → 2.1.1, CHANGELOG entry.

## Reproduction covered

The #36/#39 real-world case — `@openai/codex` install with a missing native binary (launcher runs, prints `spawn … ENOENT` to stderr, exits 1) — now produces the root cause in the first error message instead of requiring a manual `codex app-server` run.

## Testing

- 9 new tests in `app-server-rpc-client.test.ts`: stderr in crash rejections and `APICallError` (exactly once), no dangling suffix when stderr is empty, ENOENT hint, unknown-subcommand-in-stderr-only hint precedence, timeout-without-crash append, excerpt shaping/truncation, post-`exit`-pre-`close` drain race, single-line warn log.
- `npm run lint && npm run typecheck && npm test && npm run build` all pass (419 passed | 1 skipped).

A byte-identical production change ships for the 1.x line in the companion PR against `ai-sdk-v6`.