### PR TITLE
fix: never place inline MCP bearerToken on the codex command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2026-07-22
+
+### Security
+
+- The exec provider no longer places an inline MCP HTTP `bearerToken` on the spawned codex command line (previously serialized as `-c mcp_servers.<name>.http_headers.Authorization=Bearer <token>`, readable by any local process via `ps` or `/proc/<pid>/cmdline`). The token is now passed through a synthesized child-environment variable (`CODEX_MCP_<NAME>_BEARER_TOKEN`) referenced via `bearer_token_env_var` (#42). If both `bearerToken` and `bearerTokenEnvVar` are set, `bearerTokenEnvVar` wins and the inline token is ignored with a warning; an explicit `Authorization` entry in `httpHeaders` still takes precedence over `bearerToken`. The app-server transport is unaffected (MCP config travels over JSON-RPC stdin, not argv). Prefer `bearerTokenEnvVar` over inline `bearerToken`, and keep secrets out of `httpHeaders` (values ride argv) — use `envHttpHeaders` instead.
+
 ## [2.1.1] - 2026-07-10
 
 ### Fixed

--- a/docs/ai-sdk-v7/configuration.md
+++ b/docs/ai-sdk-v7/configuration.md
@@ -51,6 +51,13 @@ Model IDs are discovered, not hard-coded: use `listModels()` / `provider.listMod
   - **Stdio servers** (`transport: 'stdio'`): `command` (required), `args?`, `env?`, `cwd?`.
   - **HTTP/RMCP servers** (`transport: 'http'`): `url` (required), `bearerToken?`, `bearerTokenEnvVar?`, `httpHeaders?`, `envHttpHeaders?`.
 
+Auth notes for HTTP servers:
+
+- Prefer `bearerTokenEnvVar` (the name of an environment variable holding the token) over an inline `bearerToken`.
+- With the exec provider, an inline `bearerToken` is never placed on the codex command line: the provider passes it to the spawned process through a synthesized environment variable (`CODEX_MCP_<NAME>_BEARER_TOKEN`) and emits `bearer_token_env_var` pointing at it, so the secret is not visible in `ps` output or `/proc/<pid>/cmdline`.
+- If both `bearerToken` and `bearerTokenEnvVar` are set, `bearerTokenEnvVar` wins and the inline token is ignored (a warning is logged).
+- An explicit `Authorization` key in `httpHeaders` takes precedence over `bearerToken`. Note that `httpHeaders` values are passed as `-c` arguments on the exec provider's command line — put secrets in `bearerTokenEnvVar` or `envHttpHeaders` instead of `httpHeaders`.
+
 Example:
 
 ```ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-codex-cli",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-codex-cli",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "AI SDK v7 provider for OpenAI Codex CLI (use ChatGPT Plus/Pro subscription)",
   "keywords": [
     "ai-sdk",

--- a/src/__tests__/codex-cli-language-model.test.ts
+++ b/src/__tests__/codex-cli-language-model.test.ts
@@ -980,9 +980,11 @@ describe('CodexCliLanguageModel', () => {
       expect(argsCaptured).toContain('mcp_servers.remote.bearer_token_env_var=MCP_TOKEN');
       expect(argsCaptured).toContain('mcp_servers.remote.http_headers.x-debug=1');
       expect(argsCaptured).toContain('mcp_servers.direct.url=https://direct.example');
+      // Inline bearer tokens are routed through the child environment, never argv
       expect(argsCaptured).toContain(
-        'mcp_servers.direct.http_headers.Authorization=Bearer DIRECT_TOKEN',
+        'mcp_servers.direct.bearer_token_env_var=CODEX_MCP_DIRECT_BEARER_TOKEN',
       );
+      expect(argsCaptured.some((arg) => arg.includes('DIRECT_TOKEN'))).toBe(false);
       expect(argsCaptured.some((arg) => arg.includes('mcp_servers.direct.bearer_token='))).toBe(
         false,
       );

--- a/src/__tests__/exec-language-model.test.ts
+++ b/src/__tests__/exec-language-model.test.ts
@@ -47,9 +47,12 @@ function makeMockSpawn(lines: string[], exitCode = 0) {
 
 // Mock child_process
 vi.mock('node:child_process', async () => {
-  let currentMock: (cmd: string, args: string[]) => any = makeMockSpawn([], 0) as any;
+  let currentMock: (cmd: string, args: string[], opts?: object) => any = makeMockSpawn(
+    [],
+    0,
+  ) as any;
   const mod = {
-    spawn: (cmd: string, args: string[]) => currentMock(cmd, args),
+    spawn: (cmd: string, args: string[], opts?: object) => currentMock(cmd, args, opts),
     __setSpawnMock: (fn: any) => {
       currentMock = fn;
     },
@@ -1237,6 +1240,7 @@ describe('ExecLanguageModel', () => {
 
     it('merges MCP servers across constructor and providerOptions', async () => {
       let argsCaptured: string[] = [];
+      let envCaptured: Record<string, string | undefined> = {};
       const lines = [
         JSON.stringify({ type: 'thread.started', thread_id: 'thread-mcp-merge' }),
         JSON.stringify({
@@ -1244,8 +1248,9 @@ describe('ExecLanguageModel', () => {
           item: { item_type: 'assistant_message', text: 'ok' },
         }),
       ];
-      (childProc as any).__setSpawnMock((cmd: string, args: string[]) => {
+      (childProc as any).__setSpawnMock((cmd: string, args: string[], opts?: { env?: any }) => {
         argsCaptured = args;
+        envCaptured = opts?.env ?? {};
         return makeMockSpawn(lines, 0)(cmd, args);
       });
 
@@ -1302,9 +1307,12 @@ describe('ExecLanguageModel', () => {
       expect(argsCaptured).toContain('mcp_servers.remote.bearer_token_env_var=MCP_TOKEN');
       expect(argsCaptured).toContain('mcp_servers.remote.http_headers.x-debug=1');
       expect(argsCaptured).toContain('mcp_servers.direct.url=https://direct.example');
+      // Inline bearer tokens are routed through the child environment, never argv
       expect(argsCaptured).toContain(
-        'mcp_servers.direct.http_headers.Authorization=Bearer DIRECT_TOKEN',
+        'mcp_servers.direct.bearer_token_env_var=CODEX_MCP_DIRECT_BEARER_TOKEN',
       );
+      expect(envCaptured.CODEX_MCP_DIRECT_BEARER_TOKEN).toBe('DIRECT_TOKEN');
+      expect(argsCaptured.some((arg) => arg.includes('DIRECT_TOKEN'))).toBe(false);
       expect(argsCaptured.some((arg) => arg.includes('mcp_servers.direct.bearer_token='))).toBe(
         false,
       );
@@ -1470,6 +1478,129 @@ describe('ExecLanguageModel', () => {
           arg.includes('mcp_servers.remote.http_headers.Authorization=Bearer base-token-secret'),
         ),
       ).toBe(false);
+    });
+
+    it('never places inline bearerToken in argv; routes it via the child env', async () => {
+      let argsCaptured: string[] = [];
+      let envCaptured: Record<string, string | undefined> = {};
+      const lines = [
+        JSON.stringify({ type: 'thread.started', thread_id: 'thread-bearer-env' }),
+        JSON.stringify({
+          type: 'item.completed',
+          item: { item_type: 'assistant_message', text: 'ok' },
+        }),
+      ];
+      (childProc as any).__setSpawnMock((cmd: string, args: string[], opts?: { env?: any }) => {
+        argsCaptured = args;
+        envCaptured = opts?.env ?? {};
+        return makeMockSpawn(lines, 0)(cmd, args);
+      });
+
+      const model = new ExecLanguageModel({
+        id: 'gpt-5',
+        settings: {
+          allowNpx: true,
+          mcpServers: {
+            docs: {
+              transport: 'http',
+              url: 'https://mcp.example',
+              bearerToken: 'sk-mcp-secret',
+              httpHeaders: { 'x-debug': '1' },
+            },
+          },
+        },
+      });
+
+      await model.doGenerate({ prompt: [{ role: 'user', content: 'Hi' }] as any });
+
+      expect(argsCaptured).toContain(
+        'mcp_servers.docs.bearer_token_env_var=CODEX_MCP_DOCS_BEARER_TOKEN',
+      );
+      expect(envCaptured.CODEX_MCP_DOCS_BEARER_TOKEN).toBe('sk-mcp-secret');
+      // Non-secret headers still pass through argv; the token never does
+      expect(argsCaptured).toContain('mcp_servers.docs.http_headers.x-debug=1');
+      expect(argsCaptured.some((arg) => arg.includes('sk-mcp-secret'))).toBe(false);
+    });
+
+    it('prefers explicit bearerTokenEnvVar over inline bearerToken when both are set', async () => {
+      let argsCaptured: string[] = [];
+      let envCaptured: Record<string, string | undefined> = {};
+      const lines = [
+        JSON.stringify({ type: 'thread.started', thread_id: 'thread-bearer-both' }),
+        JSON.stringify({
+          type: 'item.completed',
+          item: { item_type: 'assistant_message', text: 'ok' },
+        }),
+      ];
+      (childProc as any).__setSpawnMock((cmd: string, args: string[], opts?: { env?: any }) => {
+        argsCaptured = args;
+        envCaptured = opts?.env ?? {};
+        return makeMockSpawn(lines, 0)(cmd, args);
+      });
+
+      const model = new ExecLanguageModel({
+        id: 'gpt-5',
+        settings: {
+          allowNpx: true,
+          mcpServers: {
+            docs: {
+              transport: 'http',
+              url: 'https://mcp.example',
+              bearerToken: 'sk-mcp-secret',
+              bearerTokenEnvVar: 'MY_TOKEN_VAR',
+            },
+          },
+        },
+      });
+
+      await model.doGenerate({ prompt: [{ role: 'user', content: 'Hi' }] as any });
+
+      expect(argsCaptured).toContain('mcp_servers.docs.bearer_token_env_var=MY_TOKEN_VAR');
+      expect(envCaptured.CODEX_MCP_DOCS_BEARER_TOKEN).toBeUndefined();
+      expect(argsCaptured.some((arg) => arg.includes('sk-mcp-secret'))).toBe(false);
+    });
+
+    it('lets an explicit Authorization header win over inline bearerToken without leaking the token', async () => {
+      let argsCaptured: string[] = [];
+      let envCaptured: Record<string, string | undefined> = {};
+      const lines = [
+        JSON.stringify({ type: 'thread.started', thread_id: 'thread-bearer-explicit-auth' }),
+        JSON.stringify({
+          type: 'item.completed',
+          item: { item_type: 'assistant_message', text: 'ok' },
+        }),
+      ];
+      (childProc as any).__setSpawnMock((cmd: string, args: string[], opts?: { env?: any }) => {
+        argsCaptured = args;
+        envCaptured = opts?.env ?? {};
+        return makeMockSpawn(lines, 0)(cmd, args);
+      });
+
+      const model = new ExecLanguageModel({
+        id: 'gpt-5',
+        settings: {
+          allowNpx: true,
+          mcpServers: {
+            docs: {
+              transport: 'http',
+              url: 'https://mcp.example',
+              bearerToken: 'sk-mcp-secret',
+              httpHeaders: { Authorization: 'Basic explicit-credentials' },
+            },
+          },
+        },
+      });
+
+      await model.doGenerate({ prompt: [{ role: 'user', content: 'Hi' }] as any });
+
+      expect(argsCaptured).toContain(
+        'mcp_servers.docs.http_headers.Authorization=Basic explicit-credentials',
+      );
+      expect(
+        argsCaptured.some((arg) => arg.includes('mcp_servers.docs.bearer_token_env_var=')),
+      ).toBe(false);
+      expect(envCaptured.CODEX_MCP_DOCS_BEARER_TOKEN).toBeUndefined();
+      expect(argsCaptured.some((arg) => arg.includes('sk-mcp-secret'))).toBe(false);
     });
 
     it('merges addDirs from providerOptions with constructor settings', async () => {

--- a/src/exec-language-model.ts
+++ b/src/exec-language-model.ts
@@ -42,7 +42,6 @@ import {
   isPlainObject,
   mapCodexCliFinishReason,
   mapUnsupportedSettingsWarnings,
-  mcpHttpHeadersWithBearerToken,
   mergeMcpServers,
   safeStringify,
   sanitizeJsonSchema,
@@ -274,7 +273,7 @@ export class ExecLanguageModel implements LanguageModelV4 {
     }
 
     // MCP configuration
-    this.applyMcpSettings(args, settings);
+    const mcpSecretEnv = this.applyMcpSettings(args, settings);
 
     // Color handling
     if (settings.color) {
@@ -338,6 +337,7 @@ export class ExecLanguageModel implements LanguageModelV4 {
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       ...(settings.env || {}),
+      ...mcpSecretEnv,
       RUST_LOG: process.env.RUST_LOG || 'error',
     };
 
@@ -376,12 +376,25 @@ export class ExecLanguageModel implements LanguageModelV4 {
     };
   }
 
-  private applyMcpSettings(args: string[], settings: CodexExecSettings): void {
+  /**
+   * Apply MCP server settings as `-c` config overrides.
+   *
+   * Returns environment variables that must be set on the spawned codex
+   * process. Inline HTTP `bearerToken` secrets are routed through the child
+   * environment (via `bearer_token_env_var`) instead of argv, because command
+   * lines are readable by any local process (`ps`, /proc/<pid>/cmdline).
+   */
+  private applyMcpSettings(
+    args: string[],
+    settings: CodexExecSettings,
+  ): Record<string, string> | undefined {
     if (settings.rmcpClient) {
       this.addConfigOverride(args, 'features.rmcp_client', true);
     }
 
-    if (!settings.mcpServers) return;
+    if (!settings.mcpServers) return undefined;
+
+    const secretEnv: Record<string, string> = {};
 
     for (const [rawName, server] of Object.entries(settings.mcpServers)) {
       const name = assertValidMcpServerName(rawName);
@@ -410,15 +423,45 @@ export class ExecLanguageModel implements LanguageModelV4 {
         if (server.cwd) this.addConfigOverride(args, `${prefix}.cwd`, server.cwd);
       } else {
         this.addConfigOverride(args, `${prefix}.url`, server.url);
-        if (server.bearerTokenEnvVar)
+        const hasExplicitAuthorizationHeader = Object.keys(server.httpHeaders ?? {}).some(
+          (key) => key.toLowerCase() === 'authorization',
+        );
+        if (server.bearerTokenEnvVar) {
           this.addConfigOverride(args, `${prefix}.bearer_token_env_var`, server.bearerTokenEnvVar);
-        const httpHeaders = mcpHttpHeadersWithBearerToken(server);
-        if (httpHeaders !== undefined)
-          this.addConfigOverride(args, `${prefix}.http_headers`, httpHeaders);
+          if (server.bearerToken !== undefined) {
+            this.logger.warn(
+              `[codex-cli] MCP server '${name}': both bearerToken and bearerTokenEnvVar are set; using bearerTokenEnvVar and ignoring the inline token.`,
+            );
+          }
+        } else if (server.bearerToken !== undefined && !hasExplicitAuthorizationHeader) {
+          const envVarName = this.allocateBearerTokenEnvVar(name, secretEnv);
+          secretEnv[envVarName] = server.bearerToken;
+          this.addConfigOverride(args, `${prefix}.bearer_token_env_var`, envVarName);
+        }
+        if (server.httpHeaders !== undefined)
+          this.addConfigOverride(args, `${prefix}.http_headers`, server.httpHeaders);
         if (server.envHttpHeaders !== undefined)
           this.addConfigOverride(args, `${prefix}.env_http_headers`, server.envHttpHeaders);
       }
     }
+
+    return Object.keys(secretEnv).length > 0 ? secretEnv : undefined;
+  }
+
+  /**
+   * Pick a child-env variable name to carry an inline MCP bearer token,
+   * avoiding collisions between server names that normalize identically
+   * (e.g. 'foo-bar' and 'foo_bar').
+   */
+  private allocateBearerTokenEnvVar(serverName: string, secretEnv: Record<string, string>): string {
+    const base = `CODEX_MCP_${serverName.toUpperCase().replace(/-/g, '_')}_BEARER_TOKEN`;
+    let candidate = base;
+    let suffix = 2;
+    while (candidate in secretEnv) {
+      candidate = `${base}_${suffix}`;
+      suffix += 1;
+    }
+    return candidate;
   }
 
   private addConfigOverride(


### PR DESCRIPTION
## Summary

An MCP HTTP server configured with an inline `bearerToken` had its token serialized into the spawned codex process argv as `-c mcp_servers.<name>.http_headers.Authorization=Bearer <token>`, where any local process could read it via `ps` or `/proc/<pid>/cmdline`. The token was also liable to land in shell history, audit logs, and process-monitoring telemetry.

The exec provider now routes the token through the child environment instead:

- The token is set on the spawned process as a synthesized environment variable (`CODEX_MCP_<NAME>_BEARER_TOKEN`, collision-safe if normalized server names clash), and the provider emits `-c mcp_servers.<name>.bearer_token_env_var=<VAR>` — codex's native mechanism for env-sourced bearer tokens. The secret never appears on the command line.
- If both `bearerToken` and `bearerTokenEnvVar` are set, `bearerTokenEnvVar` wins and the inline token is ignored (a warning is logged).
- An explicit `Authorization` key in `httpHeaders` still takes precedence over `bearerToken`, matching prior behavior.

This resolves both findings (F1 at the `applyMcpSettings` call site, F2 at the `addConfigOverride` serialization sink — same flow, one fix) from the Claude Security review `CLAUDE-SECURITY-20260723-000521` of revision fc4a97f. The app-server transport is unaffected: it already sends MCP config over JSON-RPC stdin, not argv.

## Changes

- `src/exec-language-model.ts`: `applyMcpSettings` returns secret env vars for the spawn env; new `allocateBearerTokenEnvVar` helper; drops the `mcpHttpHeadersWithBearerToken` argv path (the helper remains in use by the app-server transport, where config travels over JSON-RPC).
- Tests: spawn mock now forwards spawn options so tests can assert on the child env; updated the two tests asserting the old argv behavior; added three tests covering env routing, `bearerTokenEnvVar` precedence, and explicit-`Authorization` precedence.
- `docs/ai-sdk-v7/configuration.md`: auth notes for HTTP MCP servers — precedence rules and a warning that `httpHeaders` values ride argv, steering secrets to `bearerTokenEnvVar` / `envHttpHeaders`.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 424 passed, 1 pre-existing skip